### PR TITLE
Redesign toasts to work with absolute positioning

### DIFF
--- a/src/components/toast/index.js
+++ b/src/components/toast/index.js
@@ -1,11 +1,28 @@
 import * as React from 'react';
 import classnames from 'classnames';
 
-export default function Toast({icon, type, className, children}) {
-  return <div className={classnames('toast', type ? `toast-${type}` : null, className)}>
-    <div className="toast-icon">{icon}</div>
+export default function Toast({
+  icon,
+  type,
+  className,
+  title,
+
+  onDismiss,
+
+  children,
+}) {
+  return <div className={classnames(type ? `toast-${type}` : 'toast-primary', className)}>
+    <div className="toast-icon">
+      <div className="toast-icon-glyph">
+        {icon}
+      </div>
+    </div>
     <div className="toast-body">
-      <span>{children}</span>
+      {onDismiss ? <div className="toast-dismiss" onClick={onDismiss}>&times;</div> : null}
+      {title ? <h3 className="toast-header">{title}</h3> : null}
+      <span className={classnames('toast-text', title ? 'has-title' : 'no-title')}>
+        {children}
+      </span>
     </div>
   </div>;
 }

--- a/src/components/toast/package-lock.json
+++ b/src/components/toast/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@density/ui-toast",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "lockfileVersion": 1
 }

--- a/src/components/toast/package.json
+++ b/src/components/toast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui-toast",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "description": "Toast component",
   "main": "dist/index.js",
   "style": "dist/styles.css",

--- a/src/components/toast/story.js
+++ b/src/components/toast/story.js
@@ -6,29 +6,103 @@ import './styles.scss';
 import Toast from './index';
 
 
+const CHECKMARK = <svg width='18' height='15' viewBox='0 0 18 15' xmlns='http://www.w3.org/2000/svg'>
+  <g id='Accounts' fill='none' fillRule='evenodd' strokeLinecap='square'
+  strokeLinejoin='round'>
+      <g id='acc-003-1-r1' transform='translate(-477 -145)' stroke='#FFF' strokeWidth='1.5'>
+          <g id='Notification--Failure' transform='translate(450 116)'>
+              <polyline id='icon-check' points='28 36.9693091 33.619907 42.589216 43.7357395 30.2254207'
+              />
+          </g>
+      </g>
+  </g>
+</svg>;
+
+const INFO = <svg width='18' height='18' viewBox='0 0 18 18' xmlns='http://www.w3.org/2000/svg'>
+    <g id='Environment' fill='none' fillRule='evenodd' strokeLinejoin='round'>
+        <g id='env-001-1-r1' transform='translate(-217 -268)' stroke='#FFF' strokeWidth='1.5'>
+            <g id='col-spaces' transform='translate(170 116)'>
+                <g id='container-spaces' transform='translate(0 105)'>
+                    <g id='Notification--Failure' transform='translate(20 20)'>
+                        <g id='Page-1' transform='translate(28 28)'>
+                            <path d='M16,8 C16,12.4182222 12.4183333,16 8,16 C3.58177778,16 0,12.4182222 0,8 C0,3.58166667 3.58177778,0 8,0 C12.4183333,0 16,3.58166667 16,8 L16,8 Z'
+                            id='Stroke-1' strokeLinecap='round' />
+                            <path d='M8,12 L8,7' id='Stroke-3' strokeLinecap='square' />
+                            <path d='M8,4 L8,3.9219' id='Stroke-5' strokeLinecap='square' />
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>;
+
 storiesOf('Toast', module)
   .addWithInfo('With multiline content', () => (
-    <Toast icon={<span>&#9432;</span>}>
+    <Toast icon={INFO}>
       To link a doorway with a space, drag the doorway from below to a space on the left.
+    </Toast>
+  ))
+  .addWithInfo(`With title`, () => (
+    <Toast
+      title="Hello World?"
+      icon={CHECKMARK}
+    >
+      Your password has been updated.
     </Toast>
   ))
   .addWithInfo('Success', () => (
-    <Toast type="success" icon={<span>&#10004;</span>}>
+    <Toast type="success" icon={CHECKMARK}>
       To link a doorway with a space, drag the doorway from below to a space on the left.
     </Toast>
   ))
-  .addWithInfo('info', () => (
-    <Toast type="info" icon={<span>&#10004;</span>}>
-      To link a doorway with a space, drag the doorway from below to a space on the left.
+  .addWithInfo(`Success with title`, () => (
+    <Toast
+      type="success"
+      title="Password Updated"
+      icon={CHECKMARK}
+    >
+      Your password has been updated.
+    </Toast>
+  ))
+  .addWithInfo(`Success that's non-statically positioned`, () => (
+    <div style={{position: 'fixed', top: 20, left: 'calc(50% - 200px)', width: 400}}>
+      <Toast
+        type="success"
+        title="Password Updated"
+        icon={CHECKMARK}
+      >
+        Your password has been updated.
+      </Toast>
+    </div>
+  ))
+  .addWithInfo(`Success that's dimissable`, () => (
+    <Toast
+      type="success"
+      title="Password Updated"
+      icon={CHECKMARK}
+      onDismiss={action('Dismissing toast')}
+    >
+      Your password has been updated.
+    </Toast>
+  ))
+  .addWithInfo(`Success with a multi-line body`, () => (
+    <Toast
+      type="success"
+      title="Password Updated"
+      icon={CHECKMARK}
+      onDismiss={action('Dismissing toast')}
+    >
+      Your password has been successfully updated. foo bar baz
     </Toast>
   ))
   .addWithInfo('Warning', () => (
-    <Toast type="warning" icon={<span>&times;</span>}>
+    <Toast type="warning" icon={INFO}>
       To link a doorway with a space, drag the doorway from below to a space on the left.
     </Toast>
   ))
   .addWithInfo('Danger', () => (
-    <Toast type="danger" icon={<span>&#9760;</span>}>
+    <Toast type="danger" icon={INFO}>
       Danger danger, Mr. Ranger!
     </Toast>
   ))

--- a/src/components/toast/styles.scss
+++ b/src/components/toast/styles.scss
@@ -9,7 +9,10 @@
 @mixin make-toast($color: $brand-primary, $icon-color: #fff, $icon-size: 72px) {
   box-sizing: border-box;
   background-color: #fff;
-  overflow: hidden;
+
+  position: relative;
+
+  width: 100%;
 
   border: 1px solid $color;
   border-radius: $border-radius-base;
@@ -21,40 +24,127 @@
   font-family: $font-base;
   font-size: $font-size-base;
 
-  .toast-icon {
-    display: block;
-    width: $icon-size;
-    background-color: $color;
-    margin-right: 14px;
-
-    font-size: $font-size-x-large;
-    text-align: center;
-    line-height: $icon-size;
-    color: $icon-color;
-  }
-  .toast-body {
-    width: calc(100% - 100px);
-    height: $icon-size;
-    margin-right: 14px;
-
-    font-size: $font-size-base;
-    font-weight: $font-weight-base;
-    line-height: $line-height-base;
-
-    cursor: default;
-    user-select: none;
-
-    // Vertical align the text inside of the cell.
-    display: table;
-    & > span {
-      display: table-cell;
-      vertical-align: middle;
-    }
-  }
+  &:hover .toast-dismiss { display: block; }
 }
 
-.toast { @include make-toast; }
-.toast-primary { @include make-toast($brand-primary); }
-.toast-success { @include make-toast($brand-success); }
-.toast-danger { @include make-toast($brand-danger); }
-.toast-warning { @include make-toast($brand-warning); }
+// The toast icon is on the left side of the toast and contains a centered toast icon.
+@mixin make-toast-icon($color: $brand-primary, $icon-size: 72px, $icon-color: #fff) {
+  width: $icon-size;
+  background-color: $color;
+
+  font-size: $font-size-x-large;
+  color: $icon-color;
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+@mixin make-toast-icon-glyph($icon-size: 72px) {
+  width: $icon-size;
+  text-align: center;
+}
+
+// The toast body is the right side of the toast; it contains an optional toast header and toast
+// text.
+@mixin make-toast-body {
+  height: auto;
+
+  font-size: $font-size-base;
+  font-weight: $font-weight-base;
+  line-height: $line-height-base;
+
+  cursor: default;
+  user-select: none;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  margin-left: 16px;
+  margin-right: 16px;
+}
+
+// The header of the toast. THis is within a toast body.
+@mixin make-toast-header($color: $brand-primary) {
+  font-size: $font-size-base;
+  color: $color;
+  font-weight: 500;
+
+  margin-top: 15px;
+  margin-bottom: 5px;
+}
+
+// The main content of the toast. This is within a toast body.
+@mixin make-toast-text {
+  color: $gray-cinder;
+  margin-bottom: 12px;
+
+  // If the toast doesn't have a title above it, add a similar amount of margin to its top such
+  // that its content remains centered in the flex parent.
+  &.no-title { margin-top: 12px; }
+}
+
+// The "dismissal" x button in the upper left corner of the toast.
+@mixin make-toast-dismiss {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+
+  font-size: 18px;
+  color: $gray-dark;
+  cursor: pointer;
+
+  display: none;
+}
+
+// ----------------------------------------------------------------------------
+// Create all versions of the toast - primary, success, warning, danger.
+// ----------------------------------------------------------------------------
+
+.toast-primary {
+  @include make-toast($brand-primary);
+
+  .toast-icon { @include make-toast-icon($brand-primary); }
+  .toast-icon-glyph { @include make-toast-icon-glyph; }
+
+  .toast-body { @include make-toast-body; }
+  .toast-header { @include make-toast-header($brand-primary); }
+  .toast-text { @include make-toast-text; }
+}
+
+.toast-success {
+  @include make-toast($brand-success);
+
+  .toast-icon { @include make-toast-icon($brand-success); }
+  .toast-icon-glyph { @include make-toast-icon-glyph; }
+
+  .toast-body { @include make-toast-body; }
+  .toast-header { @include make-toast-header($brand-success); }
+  .toast-text { @include make-toast-text; }
+}
+
+.toast-warning {
+  @include make-toast($brand-warning);
+
+  .toast-icon { @include make-toast-icon($brand-warning); }
+  .toast-icon-glyph { @include make-toast-icon-glyph; }
+
+  .toast-body { @include make-toast-body; }
+  .toast-header { @include make-toast-header($brand-warning); }
+  .toast-text { @include make-toast-text; }
+}
+
+.toast-danger {
+  @include make-toast($brand-danger);
+
+  .toast-icon { @include make-toast-icon($brand-danger); }
+  .toast-icon-glyph { @include make-toast-icon-glyph; }
+
+  .toast-body { @include make-toast-body; }
+  .toast-header { @include make-toast-header($brand-danger); }
+  .toast-text { @include make-toast-text; }
+}
+
+.toast-dismiss {
+  @include make-toast-dismiss;
+}


### PR DESCRIPTION
- Remove table-cell centering, use flexbox instead
- Add `title` prop
- Add dismissal functionality built into the toast

<img width="416" alt="screen shot 2018-05-01 at 11 07 47 am" src="https://user-images.githubusercontent.com/1704236/39478262-e8749bb4-4d2f-11e8-956e-494a0a379024.png">

<img width="421" alt="screen shot 2018-05-01 at 11 08 06 am" src="https://user-images.githubusercontent.com/1704236/39478277-f4c1851c-4d2f-11e8-9404-ed7480031a2b.png">
