### PR TITLE
Only flip the caret icon in the input box select box

### DIFF
--- a/src/components/date-range-picker/package-lock.json
+++ b/src/components/date-range-picker/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui-date-range-picker",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/date-range-picker/package.json
+++ b/src/components/date-range-picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui-date-range-picker",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Date Range Picker component",
   "main": "dist/index.js",
   "style": "dist/styles.css",

--- a/src/components/input-box/index.js
+++ b/src/components/input-box/index.js
@@ -132,7 +132,9 @@ export class SelectBox extends React.Component {
           <span>{selectedValue.label}</span> :
           <span className="input-box-select-placeholder">No selection</span>
         }
-        <IconChevronDown color="primary" width={12} height={12} />
+        <div className="input-box-caret">
+          <IconChevronDown color="primary" width={12} height={12} />
+        </div>
       </div>
 
       <div

--- a/src/components/input-box/styles.scss
+++ b/src/components/input-box/styles.scss
@@ -111,7 +111,7 @@
       outline: none;
 
       // When focused, flip the caret.
-      svg { transform: rotate(180deg); }
+      .input-box-caret { transform: rotate(180deg); }
     }
 
     // When disabled, a selectbox is grayed out and can't be clicked.


### PR DESCRIPTION
The css in the select box would flip any icon in the input box's value. Only the caret should flip.