### PR TITLE
Adjust date range picker width

### DIFF
--- a/src/components/date-range-picker/package-lock.json
+++ b/src/components/date-range-picker/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui-date-range-picker",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/date-range-picker/package.json
+++ b/src/components/date-range-picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui-date-range-picker",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Date Range Picker component",
   "main": "dist/index.js",
   "style": "dist/styles.css",

--- a/src/components/date-range-picker/styles.scss
+++ b/src/components/date-range-picker/styles.scss
@@ -761,6 +761,7 @@ $brand-primary-light: #B2D6FF;
 
   // Define an explicit width for the the select box value and the menu.
   // This is required so that if right aligned the menu can be moved left.
+  width: auto;
   .input-box-select-box-value { width: $value-width; }
   .input-box-select-box-menu { width: $menu-width; }
 


### PR DESCRIPTION
Right aligned date range pickers are too wide. This fixes that.

![screen shot 2018-06-18 at 9 25 14 am](https://user-images.githubusercontent.com/1704236/41539169-16af8482-72db-11e8-9669-116e0c3d0d5e.png)
