### PR TITLE
Method to export variables for non-bundled density ui

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ bootstrap:
 		pushd src/components/$$i && npm i && popd; \
 	done
 
+.PHONY: export-variables
+export-variables:
+	@node export-variables.js
+
 .PHONY: start
 start:
 	@./node_modules/.bin/start-storybook -p $(PORT) -s public

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ help:
 	@printf "\t- make clean\tremoves the built artifacts in the dist/ directory\n"
 	@printf "\t- make build\tbuilds the main package's styles, and puts them into dist/\n"
 	@printf "\t- make publish\tpublishes the main @density/ui package to npm\n"
+	@printf "\t- make export-variables\texport all density ui variables so that they can be used in a non-bundler environment\n"
 	@echo
 	@echo
 	@echo "# Component-level targets"

--- a/export-variables.js
+++ b/export-variables.js
@@ -8,4 +8,4 @@ const results = variables.map(name => {
   };`;
 }, {});
 
-console.log(results.join('\n'));
+console.log(`// Density UI variables, version ${require('./package').version}\n${results.join('\n')}`);

--- a/export-variables.js
+++ b/export-variables.js
@@ -1,0 +1,11 @@
+// This small bit of code permits exporting variables if not running in a commonjs environment.
+const fs = require('fs');
+const variables = fs.readdirSync('./variables');
+
+const results = variables.map(name => {
+  return `window['@density/ui/variables/${name}'] = ${
+    JSON.stringify(require(`./variables/${name}`), null, 2)
+  };`;
+}, {});
+
+console.log(results.join('\n'));


### PR DESCRIPTION
A mechanism to export all variables so that density ui can be used outside of a webpack/bundler context.

Note: This isn't an officially supported use-case, but it's been requested.

```
$ make export-variables
// Density UI variables, version 5.0.3
window['@density/ui/variables/colors.json'] = {
  "grayCinder": "#222A2E",
  "grayDarkest": "#4E5457",
  "grayDarker": "#8E9299",
  "grayDark": "#B4B8BF",
  "gray": "#CBCFD6",
  "grayLight": "#E8E8ED",
  "grayLighter": "#F0F0F2",
  "grayLightest": "#FAFAFA",
  "brandPrimary": "#4198FF",
  "brandSuccess": "#80CD80",
  "brandDanger": "#FF5454",
  "brandWarning": "#FFBA08",
  "textColor": "#8E9299",
  "headerColor": "#4E5457",
  "inputFieldTextColor": "#CBCFD6",
  "inputFieldTextActiveColor": "#4E5457"
};
window['@density/ui/variables/fonts.json'] = {
  "fontBase": "\"Sailec\", \"Helvetica\", \"Arial\", sans-serif",
  "fontMonospace": "\"Source Code Pro\", \"Menlo\", \"Monaco\", \"Consolas\", \"Courier New\", monospace",
  "fontSize1": 48,
  "fontWeight1": "normal",
  "fontSize2": 24,
  "fontWeight2": "bold",
  "fontSize3": 18,
  "fontWeight3": "bold",
  "fontSize4": 14,
  "fontWeight4": "bold",
  "fontSize5": 12,
  "fontWeight5": "bold",
  "fontSize6": 10,
  "fontWeight6": "bold",
  "fontSizeBase": 14,
  "fontWeightBase": "normal",
  "lineHeightBase": 22,
  "fontSizeXSmall": 10,
  "fontSizeSmall": 12,
  "fontSizeLarge": 16,
  "fontSizeXLarge": 24
};
window['@density/ui/variables/grid.json'] = {
  "fgColumns": "24",
  "fgGutter": 10,
  "screenXsMax": 767,
  "screenSmMin": 768,
  "screenSmMax": 991,
  "screenMdMin": 992,
  "screenMdMax": 1199,
  "screenLgMin": 1200
};
window['@density/ui/variables/spacing.json'] = {
  "borderRadiusBase": 4,
  "borderRadiusSmall": 2
};
window['@density/ui/variables/timings.json'] = {
  "timingBase": "250ms",
  "timingSmall": "100ms",
  "timingLarge": "350ms"
};
```