### PR TITLE
Time segment breakdown

### DIFF
--- a/src/components/report-time-segment-breakdown/index.js
+++ b/src/components/report-time-segment-breakdown/index.js
@@ -147,7 +147,7 @@ class ReportTimeSegmentBreakdownChart extends Component {
     const end = moment.duration(timeSegment.end);
 
     const marks = [];
-    for (let i = start; i.hours() <= end.hours(); i = i.clone().add(1, 'hour')) {
+    for (let i = start; i.hours() < end.hours(); i = i.clone().add(1, 'hour')) {
       let label = i.hours();
       marks.push({
         value: label * 3600, // convert label to seconds

--- a/src/components/report-time-segment-breakdown/package-lock.json
+++ b/src/components/report-time-segment-breakdown/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui-report-time-segment-breakdown",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/report-time-segment-breakdown/package.json
+++ b/src/components/report-time-segment-breakdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui-report-time-segment-breakdown",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Report time segment breakdown component",
   "main": "dist/index.js",
   "author": "Density <engineering+javascript@density.io>",


### PR DESCRIPTION
In the case of a time segment that ends at the end of the day, the <= would mean that if `end.hours()` is 23, then `i.hours()` would never make it past 23, only up to 23