### PR TITLE
Adjust percentage colors to match the sign of the value

### DIFF
--- a/src/components/report-comparative-performance/index.js
+++ b/src/components/report-comparative-performance/index.js
@@ -122,9 +122,15 @@ export default function ReportComparativePerformance({
               <td>
                 {commaNumber(lastData.totalVisits)}{' '}
                 <span className={classnames(styles.percentage, {
-                  [styles.percentagePositive]: Math.round(visitPercentageDifference) > 0,
-                  [styles.percentageNegative]: Math.round(visitPercentageDifference) < 0,
-                })}>{peakCountPercentageDifference === Infinity ? <span>&infin;</span> : Math.round(Math.abs(visitPercentageDifference * 100) * 10) / 10}%</span>
+                  [styles.percentagePositive]: visitPercentageDifference > 0,
+                  [styles.percentageNegative]: visitPercentageDifference < 0,
+                })}>
+                  {
+                    peakCountPercentageDifference === Infinity ?
+                    <span>&infin;</span> :
+                    Math.round(Math.abs(visitPercentageDifference * 100) * 10) / 10
+                  }%
+                </span>
               </td>
             </tr>
             <tr>
@@ -135,7 +141,13 @@ export default function ReportComparativePerformance({
                 <span className={classnames(styles.percentage, {
                   [styles.percentagePositive]: peakCountPercentageDifference > 0,
                   [styles.percentageNegative]: peakCountPercentageDifference < 0,
-                })}>{peakCountPercentageDifference === Infinity ? <span>&infin;</span> : Math.round(Math.abs(peakCountPercentageDifference * 100) * 10) / 10}%</span>
+                })}>
+                  {
+                    peakCountPercentageDifference === Infinity ?
+                      <span>&infin;</span> :
+                      Math.round(Math.abs(peakCountPercentageDifference * 100) * 10) / 10
+                  }%
+                </span>
               </td>
             </tr>
             <tr>

--- a/src/components/report-comparative-performance/package-lock.json
+++ b/src/components/report-comparative-performance/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui-report-comparative-performance",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/report-comparative-performance/package.json
+++ b/src/components/report-comparative-performance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui-report-comparative-performance",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Comparative Performance component",
   "main": "dist/index.js",
   "author": "Density <engineering+javascript@density.io>",


### PR DESCRIPTION
The value had `Math.round`s around them, which since the values were
always < 1 would always round to 0.