### PR TITLE
Fix an issue with the start time of metrics

### DIFF
--- a/src/components/report-surpassed-capacity/index.js
+++ b/src/components/report-surpassed-capacity/index.js
@@ -249,7 +249,9 @@ export default function ReportSurpassedCapacity({
   // - name of the day.
   let overCapacityOnChart = false;
   let busyOnChart = false;
-  const metricsPerDayInSeconds = data.filter(day => day !== null).map((day, index) => {
+  const metricsPerDayInSeconds = data.map((day, index) => {
+    if (day === null) { return null; }
+
     const analytics = day.reduce(({quiet, busy, over}, bucket) => {
       const color = calculateColorForBucket(
         bucket.count,
@@ -282,11 +284,11 @@ export default function ReportSurpassedCapacity({
     }, {timestamp: null, count: 0});
 
     return {
-      day: moment.utc().startOf('week').add(index, 'days').format('dddd'),
+      day: startDate.clone().startOf('day').add(index, 'days').format('dddd'),
       peak,
       analytics,
     };
-  });
+  }).filter(i => i !== null);
 
   let renderMode = MODE_QUIET;
   if (overCapacityOnChart) {

--- a/src/components/report-surpassed-capacity/package-lock.json
+++ b/src/components/report-surpassed-capacity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui-report-surpassed-capacity",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/report-surpassed-capacity/package.json
+++ b/src/components/report-surpassed-capacity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui-report-surpassed-capacity",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Surpassed Capacity component",
   "main": "dist/index.js",
   "author": "Density <engineering+javascript@density.io>",


### PR DESCRIPTION
The "featured" days in the report sub header were being calculated as an offset from the start of the week. If a week had days missing due to a time segment group filter, then the day name wouldn't be calculated correctly.

Instead, calculate this value by starting at the specified `startDate` rather than the start of the week.