### PR TITLE
Ahange dashboard report grid max width

### DIFF
--- a/src/components/dashboard-report-grid/package-lock.json
+++ b/src/components/dashboard-report-grid/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@density/ui-dashboard-report-grid",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "lockfileVersion": 1
 }

--- a/src/components/dashboard-report-grid/package.json
+++ b/src/components/dashboard-report-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui-dashboard-report-grid",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "description": "Dashboard Report Grid component",
   "main": "dist/index.js",
   "author": "Density <engineering+javascript@density.io>",

--- a/src/components/dashboard-report-grid/styles.scss
+++ b/src/components/dashboard-report-grid/styles.scss
@@ -3,10 +3,6 @@
 // Local variables to the component
 @import "variables.json";
 
-.dashboardReportGridWrapper {
-  max-width: 1440px;
-}
-
 .dashboardReportGrid {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
Previously, it was capped at 1440px. Change it to be 100%.