### PR TITLE
Report expanding visual implmentation

### DIFF
--- a/src/components/report-hourly-breakdown/index.js
+++ b/src/components/report-hourly-breakdown/index.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import React from 'react';
-import ReportWrapper, { ReportCard } from '@density/ui-report-wrapper';
+import ReportWrapper, { ReportCard, ReportExpandController } from '@density/ui-report-wrapper';
 import styles from './styles.scss';
 import colorVariables from '@density/ui/variables/colors.json';
 import propTypes from 'prop-types';
@@ -61,6 +61,8 @@ export default function ReportHourlyBreakdown({
   dataStartTime,
 
   cellColorThreshold,
+
+  onReportExpand,
 }) {
   const maxValue = Math.max.apply(Math, data.map(i => i.values).reduce((a, b) => [...a, ...b], []));
   return (
@@ -115,6 +117,7 @@ export default function ReportHourlyBreakdown({
           </tbody>
         </table>
       </ReportCard>
+      <ReportExpandController onClick={onReportExpand} />
     </ReportWrapper>
   );
 }

--- a/src/components/report-hourly-breakdown/index.js
+++ b/src/components/report-hourly-breakdown/index.js
@@ -100,10 +100,10 @@ export default function ReportHourlyBreakdown({
                         key={d.date.format()}
                         style={{
                           backgroundColor: addAlphaToHex(
-                            colorVariables.brandPrimary,
+                            colorVariables.brandPrimaryNew,
                             0.1 + ((d.values[index] / maxValue) * 0.9)
                           ),
-                          color: (d.values[index] / maxValue) < cellColorThreshold ? colorVariables.brandPrimary : '#fff',
+                          color: (d.values[index] / maxValue) < cellColorThreshold ? colorVariables.brandPrimaryNew : '#fff',
                         }}
                       >
                         {d.values[index]}

--- a/src/components/report-hourly-breakdown/index.js
+++ b/src/components/report-hourly-breakdown/index.js
@@ -62,6 +62,7 @@ export default function ReportHourlyBreakdown({
 
   cellColorThreshold,
 
+  showExpandControl,
   onReportExpand,
 }) {
   const maxValue = Math.max.apply(Math, data.map(i => i.values).reduce((a, b) => [...a, ...b], []));
@@ -117,7 +118,7 @@ export default function ReportHourlyBreakdown({
           </tbody>
         </table>
       </ReportCard>
-      <ReportExpandController onClick={onReportExpand} />
+      { showExpandControl ? <ReportExpandController onClick={onReportExpand} /> : null }
     </ReportWrapper>
   );
 }

--- a/src/components/report-hourly-breakdown/package-lock.json
+++ b/src/components/report-hourly-breakdown/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@density/ui-report-hourly-breakdown",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 1
 }

--- a/src/components/report-hourly-breakdown/package.json
+++ b/src/components/report-hourly-breakdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui-report-hourly-breakdown",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Hourly Breakdown Report component",
   "main": "dist/index.js",
   "author": "Density <engineering+javascript@density.io>",

--- a/src/components/report-hourly-breakdown/story.js
+++ b/src/components/report-hourly-breakdown/story.js
@@ -8,16 +8,18 @@ import ReportHourlyBreakdown from './index';
 
 storiesOf('ReportHourlyBreakdown', module)
   .addWithInfo('Default', () => (
-    <div style={{paddingTop: 100, width: '100%'}}>
+    <div style={{paddingTop: 100, width: 800}}>
       <ReportHourlyBreakdown
         title="Hourly Breakdown"
-        startDate={moment('2018-03-14T00:00:00-04:00')}
-        endDate={moment('2018-03-20T00:00:00-04:00')}
+        startDate={moment('2018-03-12T00:00:00-04:00')}
+        endDate={moment('2018-03-18T00:00:00-04:00')}
         space={{name: 'My Space'}}
+        showExpandControl
+        onReportExpand={action('Expand report')}
 
         data={[
           {
-            date: moment.utc('2018-03-14T00:00:00Z'),
+            date: moment.utc('2018-03-12T00:00:00Z'),
             values: [
               0,
               3,
@@ -37,7 +39,7 @@ storiesOf('ReportHourlyBreakdown', module)
             ],
           },
           {
-            date: moment.utc('2018-03-15T00:00:00Z'),
+            date: moment.utc('2018-03-13T00:00:00Z'),
             values: [
               2,
               10,
@@ -57,7 +59,7 @@ storiesOf('ReportHourlyBreakdown', module)
             ],
           },
           {
-            date: moment.utc('2018-03-16T00:00:00Z'),
+            date: moment.utc('2018-03-14T00:00:00Z'),
             values: [
               1,
               4,
@@ -77,7 +79,7 @@ storiesOf('ReportHourlyBreakdown', module)
             ],
           },
           {
-            date: moment.utc('2018-03-17T00:00:00Z'),
+            date: moment.utc('2018-03-15T00:00:00Z'),
             values: [
               0,
               7,
@@ -97,7 +99,7 @@ storiesOf('ReportHourlyBreakdown', module)
             ],
           },
           {
-            date: moment.utc('2018-03-18T00:00:00Z'),
+            date: moment.utc('2018-03-16T00:00:00Z'),
             values: [
               0,
               4,
@@ -117,7 +119,7 @@ storiesOf('ReportHourlyBreakdown', module)
             ],
           },
           {
-            date: moment.utc('2018-03-19T00:00:00Z'),
+            date: moment.utc('2018-03-17T00:00:00Z'),
             values: [
               0,
               0,
@@ -137,7 +139,7 @@ storiesOf('ReportHourlyBreakdown', module)
             ],
           },
           {
-            date: moment.utc('2018-03-20T00:00:00Z'),
+            date: moment.utc('2018-03-18T00:00:00Z'),
             values: [
               0,
               0,
@@ -157,7 +159,224 @@ storiesOf('ReportHourlyBreakdown', module)
             ],
           },
         ]}
-        dataStartTime={moment('2018-03-14T00:00:00-04:00').add(6, 'hours')}
+        dataStartTime={moment('2018-03-12T00:00:00-04:00').add(6, 'hours')}
+      />
+    </div>
+  ))
+  .addWithInfo('In an expanded view', () => (
+    <div style={{paddingTop: 100, width: 1000}}>
+      <ReportHourlyBreakdown
+        title="Hourly Breakdown"
+        startDate={moment('2018-03-12T00:00:00-04:00')}
+        endDate={moment('2018-03-18T00:00:00-04:00')}
+        space={{name: 'My Space'}}
+
+        data={[
+          {
+            date: moment.utc('2018-03-12T00:00:00Z'),
+            values: [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              29,
+              41,
+              28,
+              56,
+              114,
+              176,
+              134,
+              85,
+              45,
+              34,
+              84,
+              75,
+              22,
+              20,
+              10,
+              2,
+              0,
+            ],
+          },
+          {
+            date: moment.utc('2018-03-13T00:00:00Z'),
+            values: [
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              10,
+              23,
+              52,
+              28,
+              40,
+              121,
+              198,
+              145,
+              75,
+              12,
+              18,
+              92,
+              43,
+              10,
+              5,
+              2,
+              1,
+              0,
+            ],
+          },
+          {
+            date: moment.utc('2018-03-14T00:00:00Z'),
+            values: [
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              4,
+              14,
+              36,
+              35,
+              67,
+              143,
+              167,
+              180,
+              97,
+              47,
+              35,
+              79,
+              67,
+              33,
+              30,
+              24,
+              10,
+              3,
+            ],
+          },
+          {
+            date: moment.utc('2018-03-15T00:00:00Z'),
+            values: [
+              0,
+              1,
+              1,
+              0,
+              0,
+              0,
+              7,
+              28,
+              24,
+              42,
+              95,
+              167,
+              154,
+              135,
+              110,
+              45,
+              43,
+              110,
+              87,
+              42,
+              32,
+              10,
+              2,
+              0,
+            ],
+          },
+          {
+            date: moment.utc('2018-03-16T00:00:00Z'),
+            values: [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              4,
+              14,
+              32,
+              38,
+              78,
+              210,
+              212,
+              189,
+              121,
+              87,
+              78,
+              49,
+              23,
+              12,
+              10,
+              5,
+              1,
+              0,
+            ],
+          },
+          {
+            date: moment.utc('2018-03-17T00:00:00Z'),
+            values: [
+              1,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              22,
+              34,
+              87,
+              75,
+              67,
+              30,
+              12,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+            ],
+          },
+          {
+            date: moment.utc('2018-03-18T00:00:00Z'),
+            values: [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              6,
+              4,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+            ],
+          },
+        ]}
+        dataStartTime={moment('2018-03-12T00:00:00-04:00').add(0, 'hours')}
       />
     </div>
   ))

--- a/src/components/report-hourly-breakdown/styles.scss
+++ b/src/components/report-hourly-breakdown/styles.scss
@@ -17,7 +17,7 @@
 
 .reportHourlyBreakdown td {
   color: #fff;
-  background-color: $gray; /* a default, this is overridden in the component */
+  background-color: transparent; /* a default, this is overridden in the component */
 
   line-height: 15px;
   text-align: center;

--- a/src/components/report-hourly-breakdown/styles.scss
+++ b/src/components/report-hourly-breakdown/styles.scss
@@ -17,7 +17,7 @@
 
 .reportHourlyBreakdown td {
   color: #fff;
-  background-color: $brand-primary-new;
+  background-color: $gray; /* a default, this is overridden in the component */
 
   line-height: 15px;
   text-align: center;

--- a/src/components/report-total-visits-rollup/index.js
+++ b/src/components/report-total-visits-rollup/index.js
@@ -43,6 +43,7 @@ export default class ReportTotalVisitsRollup extends Component {
       endDate,
       visits,
       mode,
+      maximumNumberOfRows, /* maximum number of rows to render */
 
       showExpandControl,
       onReportExpand,
@@ -61,19 +62,13 @@ export default class ReportTotalVisitsRollup extends Component {
       throw new Error('Visits values cannot be negative (received a value outside of that range)');
     }
 
-    // Calculate maximum number of rows to render
-    let maxNumberOfVisits = null; /* Infinity rows permitted when on detail page */
-    if (width < 800) {
-      maxNumberOfVisits = 7; /* normally, only 7 rows shown */
-    }
-
     let sortedVisits = visits.sort((a, b) => {
       return mode === LEAST_VISITED ? a.visits - b.visits : b.visits - a.visits;
     });
 
     // Remove visits from list if a limit was defined
-    if (maxNumberOfVisits) {
-      sortedVisits = sortedVisits.slice(0, maxNumberOfVisits);
+    if (maximumNumberOfRows) {
+      sortedVisits = sortedVisits.slice(0, maximumNumberOfRows);
     }
 
     // Calculate all spaces to feature in the reportsubheader. This is done by finding the first
@@ -141,10 +136,12 @@ ReportTotalVisitsRollup.propTypes = {
       visits: propTypes.number.isRequired,
     }).isRequired,
   ).isRequired,
+  maximumNumberOfRows: propTypes.number, /* defaults to null, meaning "show all rows" */
 
   showExpandControl: propTypes.bool.isRequired,
   onReportExpand: propTypes.func, /* not required if showExpandControl isn't specified */
 };
 ReportTotalVisitsRollup.defaultProps = {
   showExpandControl: false,
+  maximumNumberOfRows: null,
 };

--- a/src/components/report-total-visits-rollup/index.js
+++ b/src/components/report-total-visits-rollup/index.js
@@ -1,5 +1,9 @@
 import React, { Component } from 'react';
-import ReportWrapper, { ReportSubHeader, ReportCard } from '@density/ui-report-wrapper';
+import ReportWrapper, {
+  ReportSubHeader,
+  ReportCard,
+  ReportExpandController,
+} from '@density/ui-report-wrapper';
 import propTypes from 'prop-types';
 
 import { text } from '@density/ui';
@@ -39,6 +43,7 @@ export default class ReportTotalVisitsRollup extends Component {
       endDate,
       visits,
       mode,
+      onReportExpand,
     } = this.props;
     const { width } = this.state;
 
@@ -117,6 +122,7 @@ export default class ReportTotalVisitsRollup extends Component {
             })}
           </div>
         </ReportCard>
+        <ReportExpandController onClick={onReportExpand} />
       </ReportWrapper>
     );
   }

--- a/src/components/report-total-visits-rollup/index.js
+++ b/src/components/report-total-visits-rollup/index.js
@@ -43,6 +43,8 @@ export default class ReportTotalVisitsRollup extends Component {
       endDate,
       visits,
       mode,
+
+      showExpandControl,
       onReportExpand,
     } = this.props;
     const { width } = this.state;
@@ -122,7 +124,7 @@ export default class ReportTotalVisitsRollup extends Component {
             })}
           </div>
         </ReportCard>
-        <ReportExpandController onClick={onReportExpand} />
+        {showExpandControl ? <ReportExpandController onClick={onReportExpand} /> : null}
       </ReportWrapper>
     );
   }
@@ -139,4 +141,10 @@ ReportTotalVisitsRollup.propTypes = {
       visits: propTypes.number.isRequired,
     }).isRequired,
   ).isRequired,
+
+  showExpandControl: propTypes.bool.isRequired,
+  onReportExpand: propTypes.func, /* not required if showExpandControl isn't specified */
+};
+ReportTotalVisitsRollup.defaultProps = {
+  showExpandControl: false,
 };

--- a/src/components/report-total-visits-rollup/package-lock.json
+++ b/src/components/report-total-visits-rollup/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@density/ui-report-total-visits-rollup",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 1
 }

--- a/src/components/report-total-visits-rollup/package.json
+++ b/src/components/report-total-visits-rollup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui-report-total-visits-rollup",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Total visits rollup report component",
   "main": "dist/index.js",
   "author": "Density <engineering+javascript@density.io>",

--- a/src/components/report-total-visits-rollup/story.js
+++ b/src/components/report-total-visits-rollup/story.js
@@ -25,6 +25,7 @@ storiesOf('ReportTotalVisitsRollup', module)
           {id: 7, name: "SHOULD BE NOT INCLUDED WHEN NOT EXPANDED", visits: 80},
           {id: 8, name: "SHOULD ALSO NOT BE INCLUDED WHEN NOT ON DETAILS PAGE", visits: 79},
         ]}
+        maximumNumberOfRows={7}
         showExpandControl
         onReportExpand={action('Expand report')}
       />
@@ -49,6 +50,7 @@ storiesOf('ReportTotalVisitsRollup', module)
           {id: 7, name: "123 S. Olive Cafeteria", visits: 316},
           {id: 8, name: "456 E. Rutherford Cafeteria", visits: 59},
         ]}
+        maximumNumberOfRows={7}
         showExpandControl
         onReportExpand={action('Expand report')}
       />
@@ -70,8 +72,8 @@ storiesOf('ReportTotalVisitsRollup', module)
           {id: 4, name: "Hipster Cafe", visits: 199},
           {id: 5, name: "123 S. Olive Cafeteria", visits: 96},
           {id: 6, name: "456 E. Rutherford Cafeteria", visits: 166},
-          {id: 7, name: "SHOULD BE NOT INCLUDED WHEN NOT EXPANDED", visits: 80},
-          {id: 8, name: "SHOULD ALSO NOT BE INCLUDED WHEN NOT ON DETAILS PAGE", visits: 79},
+          {id: 7, name: "SHOULD BE NOT INCLUDED WHEN EXPANDED", visits: 80},
+          {id: 8, name: "SHOULD ALSO ONLY BE INCLUDED WHEN EXPANDED", visits: 79},
         ]}
       />
     </div>

--- a/src/components/report-total-visits-rollup/story.js
+++ b/src/components/report-total-visits-rollup/story.js
@@ -1,47 +1,78 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
 
 import moment from 'moment';
 import ReportTotalVisitsRollup, { MOST_VISITED, LEAST_VISITED } from './index';
 
 storiesOf('ReportTotalVisitsRollup', module)
   .addWithInfo('With most visited sorting', () => (
-    <ReportTotalVisitsRollup
-      title="Most visited spaces"
-      segmentName="lunch"
-      startDate={moment('2018-03-14T00:00:00-04:00')}
-      endDate={moment('2018-03-20T00:00:00-04:00')}
-      mode={MOST_VISITED}
-      visits={[
-        {id: 0, name: "Main campus eatery", visits: 150},
-        {id: 1, name: "My street cafe", visits: 100},
-        {id: 2, name: "4th floor cafeteria", visits: 130},
-        {id: 3, name: "18. War St Fish", visits: 105},
-        {id: 4, name: "Hipster Cafe", visits: 199},
-        {id: 5, name: "123 S. Olive Cafeteria", visits: 96},
-        {id: 6, name: "456 E. Rutherford Cafeteria", visits: 166},
-        {id: 7, name: "SHOULD BE NOT INCLUDED WHEN NOT EXPANDED", visits: 80},
-        {id: 8, name: "SHOULD ALSO NOT BE INCLUDED WHEN NOT ON DETAILS PAGE", visits: 79},
-      ]}
-    />
+    <div style={{width: 800, paddingTop: 100}}>
+      <ReportTotalVisitsRollup
+        title="Most visited spaces"
+        segmentName="lunch"
+        startDate={moment('2018-03-14T00:00:00-04:00')}
+        endDate={moment('2018-03-20T00:00:00-04:00')}
+        mode={MOST_VISITED}
+        visits={[
+          {id: 0, name: "Main campus eatery", visits: 150},
+          {id: 1, name: "My street cafe", visits: 100},
+          {id: 2, name: "4th floor cafeteria", visits: 130},
+          {id: 3, name: "18. War St Fish", visits: 105},
+          {id: 4, name: "Hipster Cafe", visits: 199},
+          {id: 5, name: "123 S. Olive Cafeteria", visits: 96},
+          {id: 6, name: "456 E. Rutherford Cafeteria", visits: 166},
+          {id: 7, name: "SHOULD BE NOT INCLUDED WHEN NOT EXPANDED", visits: 80},
+          {id: 8, name: "SHOULD ALSO NOT BE INCLUDED WHEN NOT ON DETAILS PAGE", visits: 79},
+        ]}
+        showExpandControl
+        onReportExpand={action('Expand report')}
+      />
+    </div>
   ))
   .addWithInfo('With least visited sorting', () => (
-    <ReportTotalVisitsRollup
-      title="Least utilized spaces"
-      segmentName="dinner"
-      startDate={moment('2018-03-14T00:00:00-04:00')}
-      endDate={moment('2018-03-20T00:00:00-04:00')}
-      mode={LEAST_VISITED}
-      visits={[
-        {id: 0, name: "THIS SPACE SHOULD NOT BE SHOWN", visits: 9999},
-        {id: 1, name: "THIS SPACE SHOULD NOT BE SHOWN", visits: 1000},
-        {id: 2, name: "Main campus eatery", visits: 545},
-        {id: 3, name: "My street cafe", visits: 520},
-        {id: 4, name: "4th floor cafeteria", visits: 440},
-        {id: 5, name: "18. War St Fish", visits: 407},
-        {id: 6, name: "Hipster Cafe", visits: 0},
-        {id: 7, name: "123 S. Olive Cafeteria", visits: 316},
-        {id: 8, name: "456 E. Rutherford Cafeteria", visits: 59},
-      ]}
-    />
+    <div style={{width: 800, paddingTop: 100}}>
+      <ReportTotalVisitsRollup
+        title="Least utilized spaces"
+        segmentName="dinner"
+        startDate={moment('2018-03-14T00:00:00-04:00')}
+        endDate={moment('2018-03-20T00:00:00-04:00')}
+        mode={LEAST_VISITED}
+        visits={[
+          {id: 0, name: "THIS SPACE SHOULD NOT BE SHOWN", visits: 9999},
+          {id: 1, name: "THIS SPACE SHOULD NOT BE SHOWN", visits: 1000},
+          {id: 2, name: "Main campus eatery", visits: 545},
+          {id: 3, name: "My street cafe", visits: 520},
+          {id: 4, name: "4th floor cafeteria", visits: 440},
+          {id: 5, name: "18. War St Fish", visits: 407},
+          {id: 6, name: "Hipster Cafe", visits: 0},
+          {id: 7, name: "123 S. Olive Cafeteria", visits: 316},
+          {id: 8, name: "456 E. Rutherford Cafeteria", visits: 59},
+        ]}
+        showExpandControl
+        onReportExpand={action('Expand report')}
+      />
+    </div>
+  ))
+  .addWithInfo('In an expanded view, with a width of 1000', () => (
+    <div style={{width: 1000, paddingTop: 100}}>
+      <ReportTotalVisitsRollup
+        title="Most visited spaces"
+        segmentName="lunch"
+        startDate={moment('2018-03-14T00:00:00-04:00')}
+        endDate={moment('2018-03-20T00:00:00-04:00')}
+        mode={MOST_VISITED}
+        visits={[
+          {id: 0, name: "Main campus eatery", visits: 150},
+          {id: 1, name: "My street cafe", visits: 100},
+          {id: 2, name: "4th floor cafeteria", visits: 130},
+          {id: 3, name: "18. War St Fish", visits: 105},
+          {id: 4, name: "Hipster Cafe", visits: 199},
+          {id: 5, name: "123 S. Olive Cafeteria", visits: 96},
+          {id: 6, name: "456 E. Rutherford Cafeteria", visits: 166},
+          {id: 7, name: "SHOULD BE NOT INCLUDED WHEN NOT EXPANDED", visits: 80},
+          {id: 8, name: "SHOULD ALSO NOT BE INCLUDED WHEN NOT ON DETAILS PAGE", visits: 79},
+        ]}
+      />
+    </div>
   ))

--- a/src/components/report-utilization/index.js
+++ b/src/components/report-utilization/index.js
@@ -39,6 +39,7 @@ export default class ReportUtilization extends Component {
       endDate,
       utilizations,
       mode,
+      maximumNumberOfRows,
       showExpandControl,
       onReportExpand,
     } = this.props;
@@ -57,11 +58,6 @@ export default class ReportUtilization extends Component {
     }
 
     // Calculate maximum number of rows to render
-    let maxNumberOfUtilizations = null; /* Infinity rows permitted when on detail page */
-    if (width < 800) {
-      maxNumberOfUtilizations = 7; /* normally, only 7 rows shown */
-    }
-
     let sortedUtilizations = utilizations.sort((a, b) => {
       if (mode === LEAST_UTILIZED) {
         return a.utilization - b.utilization;
@@ -71,8 +67,8 @@ export default class ReportUtilization extends Component {
     });
 
     // Remove utilizations from list if a limit was defined
-    if (maxNumberOfUtilizations) {
-      sortedUtilizations = sortedUtilizations.slice(0, maxNumberOfUtilizations);
+    if (maximumNumberOfRows) {
+      sortedUtilizations = sortedUtilizations.slice(0, maximumNumberOfRows);
     }
 
     // Calculate all spaces to feature in the reportsubheader. This is done by finding the first
@@ -138,10 +134,12 @@ ReportUtilization.propTypes = {
       utilization: propTypes.number.isRequired,
     }).isRequired,
   ).isRequired,
+  maximumNumberOfRows: propTypes.number, /* defaults to null, meaning "show all rows" */
 
   showExpandControl: propTypes.bool.isRequired,
   onReportExpand: propTypes.func, /* not required if showExpandControl isn't specified */
 };
 ReportUtilization.defaultProps = {
   showExpandControl: false,
+  maximumNumberOfRows: null,
 };

--- a/src/components/report-utilization/index.js
+++ b/src/components/report-utilization/index.js
@@ -39,6 +39,7 @@ export default class ReportUtilization extends Component {
       endDate,
       utilizations,
       mode,
+      showExpandControl,
       onReportExpand,
     } = this.props;
     const { width } = this.state;
@@ -120,7 +121,7 @@ export default class ReportUtilization extends Component {
             })}
           </div>
         </ReportCard>
-        <ReportExpandController onClick={onReportExpand} />
+        {showExpandControl ? <ReportExpandController onClick={onReportExpand} /> : null}
       </ReportWrapper>
     );
   }
@@ -137,4 +138,10 @@ ReportUtilization.propTypes = {
       utilization: propTypes.number.isRequired,
     }).isRequired,
   ).isRequired,
+
+  showExpandControl: propTypes.bool.isRequired,
+  onReportExpand: propTypes.func, /* not required if showExpandControl isn't specified */
+};
+ReportUtilization.defaultProps = {
+  showExpandControl: false,
 };

--- a/src/components/report-utilization/index.js
+++ b/src/components/report-utilization/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import ReportWrapper, { ReportSubHeader, ReportCard } from '@density/ui-report-wrapper';
+import ReportWrapper, { ReportSubHeader, ReportCard, ReportExpandController } from '@density/ui-report-wrapper';
 import propTypes from 'prop-types';
 
 import { text } from '@density/ui';
@@ -39,6 +39,7 @@ export default class ReportUtilization extends Component {
       endDate,
       utilizations,
       mode,
+      onReportExpand,
     } = this.props;
     const { width } = this.state;
 
@@ -119,6 +120,7 @@ export default class ReportUtilization extends Component {
             })}
           </div>
         </ReportCard>
+        <ReportExpandController onClick={onReportExpand} />
       </ReportWrapper>
     );
   }

--- a/src/components/report-utilization/package-lock.json
+++ b/src/components/report-utilization/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@density/ui-report-utilization",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "lockfileVersion": 1
 }

--- a/src/components/report-utilization/package.json
+++ b/src/components/report-utilization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui-report-utilization",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Utilization report component",
   "main": "dist/index.js",
   "author": "Density <engineering+javascript@density.io>",

--- a/src/components/report-utilization/story.js
+++ b/src/components/report-utilization/story.js
@@ -7,40 +7,69 @@ import ReportUtilization, { MOST_UTILIZED, LEAST_UTILIZED } from './index';
 
 storiesOf('ReportUtilization', module)
   .addWithInfo('With most utilized sorting', () => (
-    <ReportUtilization
-      title="Most utilized spaces"
-      startDate={moment('2018-03-14T00:00:00-04:00')}
-      endDate={moment('2018-03-20T00:00:00-04:00')}
-      mode={MOST_UTILIZED}
-      utilizations={[
-        {id: 0, name: "Main campus eatery", utilization: 0.93},
-        {id: 1, name: "My street cafe", utilization: 0.93},
-        {id: 2, name: "4th floor cafeteria", utilization: 0.55},
-        {id: 3, name: "18. War St Fish", utilization: 0.32},
-        {id: 4, name: "Hipster Cafe", utilization: 0.21},
-        {id: 5, name: "123 S. Olive Cafeteria", utilization: 0.18},
-        {id: 6, name: "456 E. Rutherford Cafeteria", utilization: 0.02},
-        {id: 7, name: "SHOULD BE NOT INCLUDED WHEN NOT EXPANDED", utilization: 0.01},
-        {id: 8, name: "SHOULD ALSO NOT BE INCLUDED WHEN NOT ON DETAILS PAGE", utilization: 0.01},
-      ]}
-    />
+    <div style={{width: 800, paddingTop: 100}}>
+      <ReportUtilization
+        title="Most utilized spaces"
+        startDate={moment('2018-03-14T00:00:00-04:00')}
+        endDate={moment('2018-03-20T00:00:00-04:00')}
+        mode={MOST_UTILIZED}
+        utilizations={[
+          {id: 0, name: "Main campus eatery", utilization: 0.93},
+          {id: 1, name: "My street cafe", utilization: 0.93},
+          {id: 2, name: "4th floor cafeteria", utilization: 0.55},
+          {id: 3, name: "18. War St Fish", utilization: 0.32},
+          {id: 4, name: "Hipster Cafe", utilization: 0.21},
+          {id: 5, name: "123 S. Olive Cafeteria", utilization: 0.18},
+          {id: 6, name: "456 E. Rutherford Cafeteria", utilization: 0.02},
+          {id: 7, name: "SHOULD BE NOT INCLUDED WHEN NOT EXPANDED", utilization: 0.01},
+          {id: 8, name: "SHOULD ALSO NOT BE INCLUDED WHEN NOT ON DETAILS PAGE", utilization: 0.01},
+        ]}
+        showExpandControl
+        onReportExpand={action('Expand report')}
+      />
+    </div>
   ))
   .addWithInfo('With least utilized sorting', () => (
-    <ReportUtilization
-      title="Least utilized spaces"
-      startDate={moment('2018-03-14T00:00:00-04:00')}
-      endDate={moment('2018-03-20T00:00:00-04:00')}
-      mode={LEAST_UTILIZED}
-      utilizations={[
-        {id: 0, name: "THIS SPACE SHOULD NOT BE SHOWN", utilization: 0.99},
-        {id: 1, name: "THIS SPACE SHOULD NOT BE SHOWN", utilization: 0.99},
-        {id: 2, name: "Main campus eatery", utilization: 0.93},
-        {id: 3, name: "My street cafe", utilization: 0.93},
-        {id: 4, name: "4th floor cafeteria", utilization: 0.55},
-        {id: 5, name: "18. War St Fish", utilization: 0.32},
-        {id: 6, name: "Hipster Cafe", utilization: 0.21},
-        {id: 7, name: "123 S. Olive Cafeteria", utilization: 0.18},
-        {id: 8, name: "456 E. Rutherford Cafeteria", utilization: 0.02},
-      ]}
-    />
+    <div style={{width: 800, paddingTop: 100}}>
+      <ReportUtilization
+        title="Least utilized spaces"
+        startDate={moment('2018-03-14T00:00:00-04:00')}
+        endDate={moment('2018-03-20T00:00:00-04:00')}
+        mode={LEAST_UTILIZED}
+        utilizations={[
+          {id: 0, name: "THIS SPACE SHOULD NOT BE SHOWN", utilization: 0.99},
+          {id: 1, name: "THIS SPACE SHOULD NOT BE SHOWN", utilization: 0.99},
+          {id: 2, name: "Main campus eatery", utilization: 0.93},
+          {id: 3, name: "My street cafe", utilization: 0.93},
+          {id: 4, name: "4th floor cafeteria", utilization: 0.55},
+          {id: 5, name: "18. War St Fish", utilization: 0.32},
+          {id: 6, name: "Hipster Cafe", utilization: 0.21},
+          {id: 7, name: "123 S. Olive Cafeteria", utilization: 0.18},
+          {id: 8, name: "456 E. Rutherford Cafeteria", utilization: 0.02},
+        ]}
+        showExpandControl
+        onReportExpand={action('Expand report')}
+      />
+    </div>
+  ))
+  .addWithInfo('In an expanded view, with a width of 1000', () => (
+    <div style={{width: 1000, paddingTop: 100}}>
+      <ReportUtilization
+        title="Least utilized spaces"
+        startDate={moment('2018-03-14T00:00:00-04:00')}
+        endDate={moment('2018-03-20T00:00:00-04:00')}
+        mode={LEAST_UTILIZED}
+        utilizations={[
+          {id: 0, name: "THIS SPACE SHOULD ONLY BE SHOWN IN THE EXPANDED VIEW", utilization: 0.99},
+          {id: 1, name: "THIS SPACE SHOULD ONLY BE SHOWN IN THE EXPANDED VIEW", utilization: 0.99},
+          {id: 2, name: "Main campus eatery", utilization: 0.93},
+          {id: 3, name: "My street cafe", utilization: 0.93},
+          {id: 4, name: "4th floor cafeteria", utilization: 0.55},
+          {id: 5, name: "18. War St Fish", utilization: 0.32},
+          {id: 6, name: "Hipster Cafe", utilization: 0.21},
+          {id: 7, name: "123 S. Olive Cafeteria", utilization: 0.18},
+          {id: 8, name: "456 E. Rutherford Cafeteria", utilization: 0.02},
+        ]}
+      />
+    </div>
   ))

--- a/src/components/report-utilization/story.js
+++ b/src/components/report-utilization/story.js
@@ -24,6 +24,7 @@ storiesOf('ReportUtilization', module)
           {id: 7, name: "SHOULD BE NOT INCLUDED WHEN NOT EXPANDED", utilization: 0.01},
           {id: 8, name: "SHOULD ALSO NOT BE INCLUDED WHEN NOT ON DETAILS PAGE", utilization: 0.01},
         ]}
+        maximumNumberOfRows={7}
         showExpandControl
         onReportExpand={action('Expand report')}
       />
@@ -47,6 +48,7 @@ storiesOf('ReportUtilization', module)
           {id: 7, name: "123 S. Olive Cafeteria", utilization: 0.18},
           {id: 8, name: "456 E. Rutherford Cafeteria", utilization: 0.02},
         ]}
+        maximumNumberOfRows={7}
         showExpandControl
         onReportExpand={action('Expand report')}
       />

--- a/src/components/report-wrapper/index.js
+++ b/src/components/report-wrapper/index.js
@@ -108,8 +108,7 @@ export function ReportExpandController({onClick}) {
   );
 }
 ReportExpandController.propTypes = {
-  children: propTypes.node.isRequired,
-  onClick: propTypes.func,
+  onClick: propTypes.func.isRequired,
 };
 
 

--- a/src/components/report-wrapper/index.js
+++ b/src/components/report-wrapper/index.js
@@ -9,15 +9,10 @@ import colorVariables from '@density/ui/variables/colors.json';
 
 import styles from './styles.scss';
 
-export function ReportPadding({children}) {
-  return (
-    <div className={styles.reportPadding}>{children}</div>
-  );
-}
-ReportPadding.propTypes = {
-  children: propTypes.node.isRequired,
-};
-
+// ------------------------------------------------------------------------------
+// Report Card
+// The body of the card, which is contained inside of the ReportWrapper
+// ------------------------------------------------------------------------------
 export function ReportCard({children, noPadding}) {
   return (
     <div className={styles.reportCard}>
@@ -30,6 +25,26 @@ ReportCard.propTypes = {
   children: propTypes.node.isRequired,
 };
 
+
+// ------------------------------------------------------------------------------
+// Report Padding
+// Used to add spacing inside of a ReportCard
+// ------------------------------------------------------------------------------
+export function ReportPadding({children}) {
+  return (
+    <div className={styles.reportPadding}>{children}</div>
+  );
+}
+ReportPadding.propTypes = {
+  children: propTypes.node.isRequired,
+};
+
+
+// ------------------------------------------------------------------------------
+// Report Sub Header
+// Adds a section inside the ReportWrapper that contains summary information for
+// the report, such as a statistic. This goes at the same level as a ReportCard.
+// ------------------------------------------------------------------------------
 export function ReportSubHeader({
   title,
   children
@@ -51,6 +66,35 @@ ReportSubHeader.propTypes = {
   children: propTypes.node
 };
 
+// ------------------------------------------------------------------------------
+// Report Error
+// This is another thing that can be placed inside of a ReportWrapper, and it is
+// shown when a report throws an error during it's calculations or while fetching
+// data.
+// ------------------------------------------------------------------------------
+export function ReportError() {
+  return (
+    <ReportCard>
+      <div className={styles.reportError}>
+        <h3 className={styles.reportErrorHeader}>Whoops!</h3>
+        <span className={styles.reportErrorBody}>There was an issue loading this report.</span>
+        <span className={styles.reportErrorBody}>
+          Contact <a href="mailto:support@density.io">support</a>{' '}
+          and we'll get you up and running.
+        </span>
+      </div>
+    </ReportCard>
+  );
+}
+
+
+
+// ------------------------------------------------------------------------------
+// Report Option Bar
+// Renders a list of concrete options next to each other horizontally. Each is
+// assigned a name and color. Place this inside of a ReportSubHeader or
+// ReportCard.
+// ------------------------------------------------------------------------------
 export function ReportOptionBar({options}) {
   return (
     <ul className={styles.reportOptionBarList}>
@@ -74,21 +118,6 @@ ReportOptionBar.propTypes = {
   })).isRequired,
 };
 
-export function ReportError() {
-  return (
-    <ReportCard>
-      <div className={styles.reportError}>
-        <h3 className={styles.reportErrorHeader}>Whoops!</h3>
-        <span className={styles.reportErrorBody}>There was an issue loading this report.</span>
-        <span className={styles.reportErrorBody}>
-          Contact <a href="mailto:support@density.io">support</a>{' '}
-          and we'll get you up and running.
-        </span>
-      </div>
-    </ReportCard>
-  );
-}
-
 
 
 // Render the date range for the report wrapper
@@ -110,6 +139,11 @@ function ReportWrapperHeaderDateRange({startDate, endDate}) {
   }
 }
 
+// ------------------------------------------------------------------------------
+// Report Wrapper
+// This is the root element of the report, which contains multiple children like
+// ReportCards, ReportSubHeaders, or ReportErrors.
+// ------------------------------------------------------------------------------
 function ReportWrapperHeader({
   title,
   startDate,
@@ -187,3 +221,6 @@ ReportWrapper.propTypes = {
 ReportWrapper.defaultProps = {
   hideDetailsLink: true,
 };
+
+
+

--- a/src/components/report-wrapper/index.js
+++ b/src/components/report-wrapper/index.js
@@ -66,6 +66,7 @@ ReportSubHeader.propTypes = {
   children: propTypes.node
 };
 
+
 // ------------------------------------------------------------------------------
 // Report Error
 // This is another thing that can be placed inside of a ReportWrapper, and it is
@@ -86,6 +87,30 @@ export function ReportError() {
     </ReportCard>
   );
 }
+
+
+// ------------------------------------------------------------------------------
+// Report Expand Controller
+// A component to render a control in the lower right corner of a report to show
+// an expanded view of the report.
+// ------------------------------------------------------------------------------
+export function ReportExpandController({onClick}) {
+  return (
+    <ReportCard noPadding>
+      <div className={styles.reportExpandController}>
+        <div onClick={onClick} className={styles.reportExpandControllerBox}>
+          <span className={styles.reportExpandControllerBoxContent}>
+            Expand
+          </span>
+        </div>
+      </div>
+    </ReportCard>
+  );
+}
+ReportExpandController.propTypes = {
+  children: propTypes.node.isRequired,
+  onClick: propTypes.func,
+};
 
 
 

--- a/src/components/report-wrapper/package-lock.json
+++ b/src/components/report-wrapper/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui-report-wrapper",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/report-wrapper/package.json
+++ b/src/components/report-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui-report-wrapper",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Report wrapper component",
   "main": "dist/index.js",
   "author": "Density <engineering+javascript@density.io>",

--- a/src/components/report-wrapper/story.js
+++ b/src/components/report-wrapper/story.js
@@ -4,7 +4,12 @@ import { action } from '@storybook/addon-actions';
 
 import moment from 'moment';
 
-import ReportWrapper, { ReportCard, ReportPadding, ReportError } from './index';
+import ReportWrapper, {
+  ReportCard,
+  ReportPadding,
+  ReportError,
+  ReportExpandController,
+} from './index';
 
 storiesOf('ReportWrapper', module)
   .addWithInfo('ReportWrapper with ReportCard inside', () => (
@@ -103,6 +108,21 @@ storiesOf('ReportWrapper', module)
         spaces={[]}
       >
         <ReportError />
+      </ReportWrapper>
+    </div>
+  ))
+  .addWithInfo('ReportWrapper with ReportCard and ReportExpandController inside', () => (
+    <div style={{width: '100%', paddingTop: 100}}>
+      <ReportWrapper
+        title="Cafeteria meal visits abc def ghi jkl"
+        startDate={null}
+        endDate={null}
+        spaces={[]}
+      >
+        <ReportCard>
+          foo bar baz
+        </ReportCard>
+        <ReportExpandController onClick={action('Click expand')} />
       </ReportWrapper>
     </div>
   ))

--- a/src/components/report-wrapper/styles.scss
+++ b/src/components/report-wrapper/styles.scss
@@ -11,7 +11,7 @@
 
   width: 100%;
   min-width: 320px;
-  max-width: 800px;
+  max-width: 1000px;
 }
 
 

--- a/src/components/report-wrapper/styles.scss
+++ b/src/components/report-wrapper/styles.scss
@@ -171,7 +171,7 @@
 
   padding-left: 20px;
   padding-right: 20px;
-  color: $brand-primary;
+  color: $brand-primary-new;
 }
 
 

--- a/src/components/report-wrapper/styles.scss
+++ b/src/components/report-wrapper/styles.scss
@@ -141,6 +141,40 @@
 }
 
 
+.reportExpandController {
+  display: flex;
+  justify-content: flex-end;
+
+  height: 32px;
+}
+.reportExpandControllerBox {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  cursor: pointer;
+
+  border-top: 1px solid $gray;
+  border-left: 1px solid $gray;
+  border-top-left-radius: 4px;
+
+  &:hover .reportExpandControllerBoxContent { opacity: 0.8; }
+  &:active .reportExpandControllerBoxContent { opacity: 1; }
+}
+.reportExpandControllerBoxContent {
+  transform: translate(0px, 2px);
+  transition: all 100ms ease-in-out;
+
+  font-size: 12px;
+  font-weight: bold;
+  user-select: none;
+
+  padding-left: 20px;
+  padding-right: 20px;
+  color: $brand-primary;
+}
+
+
 .reportCard {
   position: relative;
   font-family: $font-base;
@@ -148,12 +182,17 @@
   background-color: $gray-lightest;
   color: $gray-cinder;
 
-  border-top: 1px solid $gray;
-  border-bottom: 1px solid $gray;
   border-left: 1px solid $gray;
   border-right: 1px solid $gray;
-  border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px;
+  border-top: 1px solid $gray; /* include a top border only on the first card in a series */
+  & + & { border-top: 0px; }
+
+  /* on the final card, add rounded corners and a bottom border */
+  &:last-child {
+    border-bottom: 1px solid $gray;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+  }
 }
 
 


### PR DESCRIPTION
- Add a new concept that can be put into a `ReportWrapper`, a `ReportExpandController`. This concept renders an "Expand" button in the lower left corner, reserving the whole row's height for the button as discussed.
![screen shot 2018-12-11 at 12 23 32 pm](https://user-images.githubusercontent.com/1704236/49817959-9935b180-fd3f-11e8-8a1a-b2b9edd4a6e9.png)

- Add an expand controller to three reports - `ReportHourlyBreakdown`, `ReportUtilization`, and `ReportTotalVisitsRollup`.
  - **Question**: how do we determine if the expand button should be shown or hidden? My initial implementation adds a prop called `showExpandControl` to each, and a prop called `onReportExpand` that is called when a click occurs. I'm worried that a) by default, it isn't shown, and b) it's adding two extra props that seem like they are an implementation detail that the developer using this maybe shouldn't be concerned with. However, this is the best way I could think to do it at the time.

- Change `ReportUtilization` and `ReportTotalVisitsRollup` to accept a prop called `maximumNumberOfRows` to control the maximum number of rows of data shown, instead of inferring this from the width.

- Finally, update `ReportWrapper` to support a maximum width of 1000px.