### PR TITLE
Add "metric" and "aggregation" props to customize hourly breakdown

### DIFF
--- a/src/components/report-hourly-breakdown/index.d.ts
+++ b/src/components/report-hourly-breakdown/index.d.ts
@@ -1,0 +1,30 @@
+import {Moment} from 'moment';
+import React from 'react';
+
+export declare type ReportHourlyBreakdownProps = {
+  title: string;
+  startDate: Moment;
+  endDate: Moment;
+  space: {
+    name: string;
+  };
+
+  data: [{
+    date: Moment;
+    values: [number];
+  }];
+
+  maxDay: null | string;
+  maxHour: number;
+  maxValue: number;
+  metric?: 'VISITS' | 'PEAKS';
+  aggregation?: 'NONE' | 'AVERAGE';
+
+  displayContext?: {
+    showExpandControl: boolean;
+    onReportExpand?: () => any;
+
+    dataStartTime: Moment;
+    dataEndTime: Moment;
+  };
+};

--- a/src/components/report-hourly-breakdown/index.js
+++ b/src/components/report-hourly-breakdown/index.js
@@ -76,6 +76,7 @@ export default function ReportHourlyBreakdown({
 }) {
 
   // Prepare labels for max start/end times
+  // Doesn't need to be in the space's tz because it's just for rendering a number of hours
   let maxTimeStart = moment().startOf('day').add(maxHour, 'hour');
   let maxTimeEnd = moment(maxTimeStart).add(1, 'hour');
   maxTimeEnd = maxTimeEnd.format('Ha');

--- a/src/components/report-hourly-breakdown/index.js
+++ b/src/components/report-hourly-breakdown/index.js
@@ -179,6 +179,12 @@ ReportHourlyBreakdown.propTypes = {
     }),
   ).isRequired,
 
+  maxDay: propTypes.string.isRequired,
+  maxHour: propTypes.number.isRequired,
+  maxValue: propTypes.number.isRequired,
+  metric: propTypes.string,
+  aggregation: propTypes.string,
+
   displayContext: propTypes.shape({
     showExpandControl: propTypes.bool.isRequired,
     onReportExpand: propTypes.func,

--- a/src/components/report-hourly-breakdown/index.js
+++ b/src/components/report-hourly-breakdown/index.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import React from 'react';
-import ReportWrapper, { ReportCard, ReportExpandController } from '@density/ui-report-wrapper';
+import ReportWrapper, { ReportCard, ReportSubHeader, ReportExpandController } from '@density/ui-report-wrapper';
 import styles from './styles.scss';
 import colorVariables from '@density/ui/variables/colors.json';
 import propTypes from 'prop-types';
@@ -58,6 +58,12 @@ export default function ReportHourlyBreakdown({
   space,
 
   data,
+  maxDay,
+  maxHour,
+  maxValue,
+  metric = 'VISITS',
+  aggregation = 'NONE',
+
   cellColorThreshold,
 
   displayContext: {
@@ -68,7 +74,18 @@ export default function ReportHourlyBreakdown({
     dataEndTime,
   },
 }) {
-  const maxValue = Math.max.apply(Math, data.map(i => i.values).reduce((a, b) => [...a, ...b], []));
+
+  // Prepare labels for max start/end times
+  let maxTimeStart = moment().startOf('day').add(maxHour, 'hour');
+  let maxTimeEnd = moment(maxTimeStart).add(1, 'hour');
+  maxTimeEnd = maxTimeEnd.format('Ha');
+  maxTimeStart = maxTimeStart.format('Ha');
+
+  // Remove 'am'/'pm' from start hour ONLY if both are the same
+  if (maxTimeStart.endsWith(maxTimeEnd.slice(-2))) {
+    maxTimeStart = maxTimeStart.slice(0, -2);
+  }
+
   return (
     <ReportWrapper
       title={title}
@@ -76,6 +93,18 @@ export default function ReportHourlyBreakdown({
       endDate={endDate}
       spaces={[space.name]}
     >
+      <ReportSubHeader
+        title={(
+          <span>
+            <strong>{maxDay}</strong> between {' '}
+            <strong>{maxTimeStart}</strong> and <strong>{maxTimeEnd}</strong> had{' '}
+            {aggregation === 'AVERAGE' ? 
+              (metric === 'PEAKS' ? 'an average peak count of ': 'an average of ') :
+              (metric === 'PEAKS' ? 'a peak count of ' : '')}
+            <strong>{maxValue}</strong>{metric === 'VISITS' ? ' visits.' : '.'}
+          </span>
+        )}
+      />
       <ReportCard>
         <table className={styles.reportHourlyBreakdown}>
           <thead>

--- a/src/components/report-hourly-breakdown/package-lock.json
+++ b/src/components/report-hourly-breakdown/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@density/ui-report-hourly-breakdown",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1
 }

--- a/src/components/report-hourly-breakdown/package.json
+++ b/src/components/report-hourly-breakdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui-report-hourly-breakdown",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Hourly Breakdown Report component",
   "main": "dist/index.js",
   "author": "Density <engineering+javascript@density.io>",

--- a/src/components/report-hourly-breakdown/story.js
+++ b/src/components/report-hourly-breakdown/story.js
@@ -223,8 +223,8 @@ storiesOf('ReportHourlyBreakdown', module)
 
         data={DATA}
         maxDay="Monday"
-        maxHour="9"
-        maxValue="999"
+        maxHour={9}
+        maxValue={999}
 
         displayContext={{
           showExpandControl: true,
@@ -246,8 +246,8 @@ storiesOf('ReportHourlyBreakdown', module)
 
         data={DATA}
         maxDay="Monday"
-        maxHour="11"
-        maxValue="999"
+        maxHour={11}
+        maxValue={999}
 
         displayContext={{
           showExpandControl: false,

--- a/src/components/report-hourly-breakdown/story.js
+++ b/src/components/report-hourly-breakdown/story.js
@@ -222,6 +222,10 @@ storiesOf('ReportHourlyBreakdown', module)
         space={{name: 'My Space'}}
 
         data={DATA}
+        maxDay="Monday"
+        maxHour="9"
+        maxValue="999"
+
         displayContext={{
           showExpandControl: true,
           onReportExpand: action('Expand report'),
@@ -241,6 +245,9 @@ storiesOf('ReportHourlyBreakdown', module)
         space={{name: 'My Space'}}
 
         data={DATA}
+        maxDay="Monday"
+        maxHour="11"
+        maxValue="999"
 
         displayContext={{
           showExpandControl: false,


### PR DESCRIPTION
This adds two props to the hourly breakdown report, for DEN-7178