### PR TITLE
App bar font weight

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "7.1.8",
+  "version": "7.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "7.1.8",
+  "version": "7.1.9",
   "description": "A UI framework for density projects",
   "scripts": {
     "build-storybook": "build-storybook",

--- a/src/app-bar/styles.scss
+++ b/src/app-bar/styles.scss
@@ -19,7 +19,7 @@
 
 .appBarTitle {
   font-size: 24px;
-  font-weight: medium;
+  font-weight: 500;
 }
 
 // Rules for "TRANSPARENT" context


### PR DESCRIPTION
At least for me in chrome, `medium` doesn't seem like a valid value

![screen shot 2019-02-26 at 9 58 18 am](https://user-images.githubusercontent.com/1704236/53422221-1078fa00-39ad-11e9-9bfd-0ff56675cdab.png)
