### PR TITLE
Add Aeonik Medium

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "9.0.4",
+  "version": "10.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "9.0.4",
+  "version": "10.0.0",
   "description": "A UI framework for density projects",
   "scripts": {
     "build-storybook": "build-storybook",

--- a/src/app-bar/styles.scss
+++ b/src/app-bar/styles.scss
@@ -1,5 +1,6 @@
 @import "../../variables/colors.json";
 @import "../../variables/spacing.json";
+@import "../../variables/fonts.json";
 
 .appBar {
   display: flex;
@@ -11,6 +12,7 @@
   height: 64px;
   padding: 0 24px;
   border-bottom: 1px solid $gray-light;
+  font-family: $font-base;
 }
 
 .appBarSection {

--- a/src/card/styles.scss
+++ b/src/card/styles.scss
@@ -230,7 +230,7 @@
   );
 }
 :global(.card-well-dark .card-well-highlight) {
-  @include make-card-well-highlight($color: #fff, $font-weight: 500);
+  @include make-card-well-highlight($color: #fff, $font-weight: bold);
 }
 
 

--- a/src/fonts/story.js
+++ b/src/fonts/story.js
@@ -8,13 +8,16 @@ import './index';
 storiesOf('Fonts', module)
   .add('Includes fonts into the page', () => (
     <span>
-    <p style={{fontFamily: fontVariables.fontBase}}>
-      This component, when imported, adds the Density standard font (Aeonik) into your page.
-      Matter of fact, this text is in Aeonik!
-    </p>
-    <pre style={{background: '#ddd', padding: 20, lineHeight: 2}}>
-      // Include in your javascript bundle<br/>
-      import '@density/ui';
-    </pre>
+      <p style={{fontFamily: fontVariables.fontBase}}>
+        This component, when imported, adds the Density standard font (Aeonik) into your page.
+        Matter of fact, this text is in Aeonik!
+      </p>
+      <pre style={{background: '#ddd', padding: 20, lineHeight: 2}}>
+        // Include in your javascript bundle<br/>
+        import '@density/ui';
+      </pre>
+      <p style={{fontFamily: fontVariables.fontBase, fontWeight: 'bold'}}>This text is in Aeonik bold</p>
+      <p style={{fontFamily: fontVariables.fontBase, fontWeight: 500}}>This text is in Aeonik medium</p>
+      <p style={{fontFamily: fontVariables.fontBase}}>This text is in Aeonik regular</p>
     </span>
-  ))
+  ), {info: {inline: false}})

--- a/src/fonts/styles.scss
+++ b/src/fonts/styles.scss
@@ -27,7 +27,7 @@ $cdn-path: "https://densityco.github.io/assets";
   src: url('#{$cdn-path}/fonts/aeonik-bold.06523ced.eot?#iefix') format('embedded-opentype'),
     url('#{$cdn-path}/fonts/aeonik-bold.07255666.woff2') format('woff2'),
     url('#{$cdn-path}/fonts/aeonik-bold.ccac5264.woff') format('woff');
-  font-weight: 500;
+  font-weight: 700;
   font-style: normal;
 }
 @font-face { /* BOLD */
@@ -46,7 +46,7 @@ $cdn-path: "https://densityco.github.io/assets";
   src: url('#{$cdn-path}/fonts/aeonik-bolditalic.79c87750.eot?#iefix') format('embedded-opentype'),
     url('#{$cdn-path}/fonts/aeonik-bolditalic.3c206f24.woff2') format('woff2'),
     url('#{$cdn-path}/fonts/aeonik-bolditalic.f3fecfb8.woff') format('woff');
-  font-weight: 500;
+  font-weight: 700;
   font-style: italic;
 }
 @font-face { /* BOLD ITALICS */
@@ -56,6 +56,25 @@ $cdn-path: "https://densityco.github.io/assets";
     url('#{$cdn-path}/fonts/aeonik-bolditalic.3c206f24.woff2') format('woff2'),
     url('#{$cdn-path}/fonts/aeonik-bolditalic.f3fecfb8.woff') format('woff');
   font-weight: bold;
+  font-style: italic;
+}
+
+@font-face { /* MEDIUM */
+  font-family: 'Aeonik';
+  src: url('#{$cdn-path}/fonts/aeonik-medium.7a81f68d.eot');
+  src: url('#{$cdn-path}/fonts/aeonik-medium.7a81f68d.eot?#iefix') format('embedded-opentype'),
+    url('#{$cdn-path}/fonts/aeonik-medium.0b69a6eb.woff2') format('woff2'),
+    url('#{$cdn-path}/fonts/aeonik-medium.87075dd8.woff') format('woff');
+  font-weight: 500;
+  font-style: normal;
+}
+@font-face { /* MEDIUM ITALICS */
+  font-family: 'Aeonik';
+  src: url('#{$cdn-path}/fonts/aeonik-mediumitalic.40ee839f.eot');
+  src: url('#{$cdn-path}/fonts/aeonik-mediumitalic.40ee839f.eot?#iefix') format('embedded-opentype'),
+    url('#{$cdn-path}/fonts/aeonik-mediumitalic.68adccc3.woff2') format('woff2'),
+    url('#{$cdn-path}/fonts/aeonik-mediumitalic.f6483939.woff') format('woff');
+  font-weight: 500;
   font-style: italic;
 }
 

--- a/src/toast/styles.scss
+++ b/src/toast/styles.scss
@@ -74,7 +74,7 @@
 // The header of the toast. THis is within a toast body.
 .toastHeader {
   font-size: $font-size-base;
-  font-weight: 500;
+  font-weight: bold;
 
   margin-top: 15px;
   margin-bottom: 5px;


### PR DESCRIPTION
- Adds Aeonik Medium font
- Readjusts font weights to be more in line with what they "typically" should be (did a bit of research):
  - Normal = `400`
  - Medium / Semibold = `500`
  - Bold = `600`

(`font-weight: bold` means `600`, and `font-weight: normal` means `400`)

I have a corresponding dashboard change to ensure that the font weights go along with this scale that I will be pushing up shortly.