### PR TITLE
Add an ellipsis to text that overflows the width of an app bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "10.1.1",
+  "version": "10.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "10.1.1",
+  "version": "10.2.0",
   "description": "A UI framework for density projects",
   "scripts": {
     "build-storybook": "build-storybook",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "A UI framework for density projects",
   "scripts": {
     "build-storybook": "build-storybook",

--- a/src/app-bar/story.js
+++ b/src/app-bar/story.js
@@ -33,3 +33,12 @@ storiesOf('AppBar', module)
       </AppBar>
     </AppBarContext.Provider>
   ))
+  .add('With a title that overflows the width of the app bar', () => (
+    <div style={{width: 500}}>
+      <AppBar>
+        <AppBarTitle>
+          Really really long title that overflows the width that it is allotted
+        </AppBarTitle>
+      </AppBar>
+    </div>
+  ))

--- a/src/app-bar/styles.scss
+++ b/src/app-bar/styles.scss
@@ -23,6 +23,9 @@
 .appBarTitle {
   font-size: 24px;
   font-weight: 500;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow-x: hidden;
 }
 
 // Rules for "TRANSPARENT" context


### PR DESCRIPTION
<img width="517" alt="screen shot 2019-03-06 at 1 01 09 pm" src="https://user-images.githubusercontent.com/1704236/53902764-edcf8c80-400f-11e9-9d99-3bf7c2059790.png">
