### PR TITLE
Change styling of the switch to match mockups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "description": "A UI framework for density projects",
   "scripts": {
     "build-storybook": "build-storybook",

--- a/src/switch/styles.scss
+++ b/src/switch/styles.scss
@@ -22,10 +22,10 @@
       height: $switch-handle-size + $switch-handle-border-size;
 
       box-sizing: border-box;
-      left: -1 * $switch-handle-border-size;
-      top: -1 * $switch-handle-border-size;
+      left: 0px;
+      top: ($switch-base-height - $switch-handle-size - $switch-handle-border-size) / 2;
       border-radius: 50%;
-      background: $foreground;
+      background-color: $foreground;
       border: $switch-handle-border-size solid $gray;
       transition: all 200ms ease;
     }
@@ -39,7 +39,7 @@
     background-color: $background;
 
     &:after {
-      left: calc(50% + #{$switch-handle-border-size});
+      left: $switch-base-width - $switch-handle-size - $switch-handle-border-size;
       border-color: $background;
     }
   }

--- a/src/switch/variables.json
+++ b/src/switch/variables.json
@@ -1,6 +1,6 @@
 {
   "switchBaseWidth": "40px",
-  "switchBaseHeight": "18px",
+  "switchBaseHeight": "24px;",
   "switchHandleSize": "20px",
   "switchHandleBorderSize": "2px"
 }


### PR DESCRIPTION
Now looks like this:
![Screen Shot 2019-03-11 at 9 50 23 AM](https://user-images.githubusercontent.com/1704236/54128751-1cb87a80-43e3-11e9-8d4a-4ffb58802654.png)

Accepts the same props, this is just a css change