### PR TITLE
Add multiline toast context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "15.4.0",
+  "version": "15.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "15.4.0",
+  "version": "15.5.0",
   "description": "A UI framework for density projects",
   "scripts": {
     "build-storybook": "build-storybook",

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ export { default as PagerButtonGroup } from './pager-button-group';
 export { default as PercentageBar } from './percentage-bar';
 export { default as RadioButton, RadioButtonContext } from './radio-button';
 export { default as Switch } from './switch';
-export { default as Toast } from './toast';
+export { default as Toast, ToastContext } from './toast';
 export { default as Skeleton } from './skeleton';
 
 export {

--- a/src/toast/index.js
+++ b/src/toast/index.js
@@ -1,13 +1,25 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import propTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 
 import styles from './styles.scss';
 
+export const ToastContext = React.createContext(null);
+
+const CONTEXT_CLASSES = {
+  multiline: styles.multiline,
+};
+
 export default function Toast({ type, visible, onDismiss, children }) {
+  const context = useContext(ToastContext);
   return (
-    <div className={classnames(styles.toast, styles[type], {[styles.visible]: visible})}>
+    <div className={classnames(
+      styles.toast,
+      styles[type],
+      CONTEXT_CLASSES[context],
+      {[styles.visible]: visible},
+    )}>
       <span className={styles.toastText}>{children}</span>
       <span role="button" className={styles.toastDismiss} onClick={onDismiss}>Dismiss</span>
     </div>

--- a/src/toast/story.js
+++ b/src/toast/story.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import './styles.scss';
-import Toast from './index';
+import Toast, { ToastContext } from './index';
 
 import Icons from '../icons';
 
@@ -17,4 +17,13 @@ storiesOf('Toast', module)
     <Toast type="error" visible onDismiss={action('onDismiss')}>
       Error performing action
     </Toast>
+  ))
+  .add('Default Toast with multiline context', () => (
+    <div style={{maxWidth: 400, width: '100%'}}>
+      <ToastContext.Provider value="multiline">
+        <Toast visible onDismiss={action('onDismiss')}>
+          To link a doorway with a space, drag the doorway from below to a space on the left.
+        </Toast>
+      </ToastContext.Provider>
+    </div>
   ))

--- a/src/toast/styles.scss
+++ b/src/toast/styles.scss
@@ -60,3 +60,16 @@
 
 .error { background-color: $brandDanger; }
 .error .toastText { color: #FFF; }
+
+
+
+.multiline {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  height: auto;
+}
+.multiline .toastText {
+  height: auto;
+  line-height: 20px;
+  white-space: normal;
+}


### PR DESCRIPTION
Toasts previously only supported one line of data. This adds a context to permit toasts to be variable height and render a variable number of lines of content.

---

<img width="620" alt="Screen Shot 2019-04-16 at 10 36 56 AM" src="https://user-images.githubusercontent.com/1704236/56218864-adfabc80-6033-11e9-9945-028a2edaf97f.png">
