### PR TITLE
Rename contexts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "15.6.1",
+  "version": "16.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "15.6.1",
+  "version": "16.0.0",
   "description": "A UI framework for density projects",
   "scripts": {
     "build-storybook": "build-storybook",

--- a/src/app-bar/index.js
+++ b/src/app-bar/index.js
@@ -6,7 +6,7 @@ import styles from './styles.scss';
 const CONTEXT_CLASSES = {
   'TRANSPARENT': styles.contextTransparent,
   'BOTTOM_ACTIONS': styles.contextBottomActions,
-  'ADMIN_LOCATIONS_EDIT_MODULE_HEADER': styles.contextAdminLocationsEditModuleHeader,
+  'CARD_HEADER': styles.cardHeader,
 };
 
 export const AppBarContext = React.createContext(null);

--- a/src/app-bar/story.js
+++ b/src/app-bar/story.js
@@ -33,8 +33,8 @@ storiesOf('AppBar', module)
       </AppBar>
     </AppBarContext.Provider>
   ))
-  .add('With ADMIN_LOCATIONS_EDIT_MODULE_HEADER context', () => (
-    <AppBarContext.Provider value="ADMIN_LOCATIONS_EDIT_MODULE_HEADER">
+  .add('With CARD_HEADER context', () => (
+    <AppBarContext.Provider value="CARD_HEADER">
       <AppBar>
         <AppBarTitle>Title</AppBarTitle>
         <AppBarSection>ASDF</AppBarSection>

--- a/src/app-bar/styles.scss
+++ b/src/app-bar/styles.scss
@@ -46,4 +46,8 @@
   border-bottom-right-radius: $borderRadiusBase;
 }
 
-.contextAdminLocationsEditModuleHeader .appBarTitle { font-size: 20px; }
+// Rules for "CARD_HEADER" context
+.cardHeader .appBarTitle {
+  font-size: 20px;
+  color: $grayDarkest;
+}

--- a/src/toast/index.js
+++ b/src/toast/index.js
@@ -8,7 +8,7 @@ import styles from './styles.scss';
 export const ToastContext = React.createContext(null);
 
 const CONTEXT_CLASSES = {
-  multiline: styles.multiline,
+  MULTILINE: styles.multiline,
 };
 
 export default function Toast({ type, visible, onDismiss, children }) {

--- a/src/toast/story.js
+++ b/src/toast/story.js
@@ -18,9 +18,9 @@ storiesOf('Toast', module)
       Error performing action
     </Toast>
   ))
-  .add('Default Toast with multiline context', () => (
+  .add('Default Toast with MULTILINE context', () => (
     <div style={{maxWidth: 400, width: '100%'}}>
-      <ToastContext.Provider value="multiline">
+      <ToastContext.Provider value="MULTILINE">
         <Toast visible onDismiss={action('onDismiss')}>
           To link a doorway with a space, drag the doorway from below to a space on the left.
         </Toast>


### PR DESCRIPTION
- Rename App Bar's `ADMIN_LOCATIONS_EDIT_MODULE_HEADER` to `CARD_HEADER`
- Rename Toast's `multiline` to `MULTILINE`