### PR TITLE
Radiobutton margin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "16.1.0",
+  "version": "16.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "16.1.0",
+  "version": "16.2.0",
   "description": "A UI framework for density projects",
   "scripts": {
     "build-storybook": "build-storybook",

--- a/src/radio-button/index.js
+++ b/src/radio-button/index.js
@@ -12,10 +12,12 @@ const CONTEXT_CLASSES = {
 
 export const RadioButtonContext = React.createContext(null);
 
-export default function RadioButton({text, name, value, checked, disabled, onChange}) {
+export default function RadioButton({text=null, name, value, defaultChecked, checked, disabled, onChange}) {
   const unique = v4();
   return <RadioButtonContext.Consumer>{context => (
-    <div className={classnames(CONTEXT_CLASSES[context], styles.radioButton)}>
+    <div className={classnames(CONTEXT_CLASSES[context], styles.radioButton, {
+      [styles.noText]: text === null,
+    })}>
       <input
         type="radio"
         className={styles.radioButtonInput}
@@ -23,6 +25,7 @@ export default function RadioButton({text, name, value, checked, disabled, onCha
         name={name}
         value={value}
         checked={checked}
+        defaultChecked={defaultChecked}
         disabled={disabled}
         onChange={onChange}
       />

--- a/src/radio-button/story.js
+++ b/src/radio-button/story.js
@@ -4,6 +4,8 @@ import { action } from '@storybook/addon-actions';
 
 import './styles.scss';
 import RadioButton, { RadioButtonContext } from './index';
+import Icons from '../icons/index';
+import colorVariables from '../../variables/colors.json';
 
 
 storiesOf('RadioButton', module)
@@ -15,14 +17,23 @@ storiesOf('RadioButton', module)
   ))
   .add('Two radio buttons, one locked on, one locked off', () => (
     <div>
-      <RadioButton text="Foo" name="story" value="foo" checked={true} disabled />
-      <RadioButton text="Bar" name="story" value="bar" checked={false} disabled />
+      <RadioButton text="Foo" name="story" value="foo" defaultChecked={true} disabled />
+      <RadioButton text="Bar" name="story" value="bar" defaultChecked={false} disabled />
     </div>
   ))
   .add('Two radio buttons controlled with click action', () => (
     <div onChange={action('Clicked')}>
       <RadioButton text="Foo" name="story" value="foo" checked={true} />
       <RadioButton text="Bar" name="story" value="bar" checked={false} />
+    </div>
+  ))
+  .add('A single radio button without a specified text value does not have a right margin', () => (
+    <div style={{display: 'flex', alignItems: 'center', height: 40, backgroundColor: colorVariables.grayLighter}}>
+      <RadioButton checked={true} />
+      <div style={{marginLeft: 8}}>
+        <Icons.Building />
+      </div>
+      <span style={{marginLeft: 8}}>Label here</span>
     </div>
   ))
   .add('With LEGACY context', () => (

--- a/src/radio-button/styles.scss
+++ b/src/radio-button/styles.scss
@@ -10,6 +10,7 @@ $radioDisabledActiveDataUri: "data:image/svg+xml,%3C%3Fxml version='1.0' encodin
 .radioButton {
   font-family: $fontBase;
   font-size: 16px;
+  height: 24px;
 }
 
 // Hide the actual radio button
@@ -29,6 +30,7 @@ $radioDisabledActiveDataUri: "data:image/svg+xml,%3C%3Fxml version='1.0' encodin
   position: relative;
   bottom: -3px;
 }
+.noText .radioButtonLabel:before { margin-right: 0px; }
 
 .radioButtonInput + .radioButtonLabel {
   color: $grayDarkest;


### PR DESCRIPTION
- When a radio button has no text defined, don't put a margin on its right side. This was likely an oversight when the radio button was originally implemented.
  - Added a story representing this case