### PR TITLE
Add logic to publish prereleases to `next` tag instead of `latest`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,16 @@ jobs:
       - run:
           name: "Publish to npm registry"
           command: |
-            set +e # This pemits the publich to fail if the version is the same as the previous commit
-            npm publish
+            # If the version has more than just xx.xx.xx, then it's a non-official release
+            tag="next"
+            if jq -r .version ./package.json | grep '^[0-9]\+.[0-9]\+.[0-9]\+$'; then
+              tag="latest"
+            fi
+
+            echo "Publishing ${jq -r .version ./package.json} to tag ${tag}"
+
+            set +e # This permits the publish to fail if the version is the same as the previous commit
+            npm publish --tag ${tag}
             set -e
 
 workflows:


### PR DESCRIPTION
More details: https://medium.com/@mbostock/prereleases-and-npm-e778fc5e2420