### PR TITLE
Tag input z-index issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "17.8.1",
+  "version": "17.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "17.8.1",
+  "version": "17.8.2",
   "description": "A UI framework for density projects",
   "scripts": {
     "build-storybook": "build-storybook",

--- a/src/tag-input/index.js
+++ b/src/tag-input/index.js
@@ -79,7 +79,7 @@ export default class TagInput extends Component {
           style={{display: dropdownOpen ? 'block' : 'none'}}
           onClick={e => this.setState({dropdownOpen: false})}
         />
-        <div className={styles.wrapper}>
+        <div className={classnames(styles.wrapper, {[styles.aboveBackdrop]: dropdownOpen})}>
           <InputBox
             type="text"
             placeholder={placeholder}

--- a/src/tag-input/story.js
+++ b/src/tag-input/story.js
@@ -1,9 +1,11 @@
-import React, { useState } from 'react';
+import React, { Fragment, useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import moment from 'moment';
 
 import './styles.scss';
 import TagInput from './index';
+import DateRangePicker, { START_DATE_ACTIVE } from '../date-range-picker/index';
 import colorVariables from '../../variables/colors.json';
 
 
@@ -141,3 +143,36 @@ storiesOf('TagInput', module)
 
     return <Wrapper />;
   })
+  .add('Should not be on top of date picker when date picker is opened', () => (
+    <Fragment>
+      <p>
+        The date picker, when opened, should show over top of the tag input.
+      </p>
+      <DateRangePicker
+        focusedInput={START_DATE_ACTIVE}
+        startDate={moment.utc()}
+        endDate={moment.utc().subtract(1, 'day')}
+      />
+      <br/>
+      <TagInput
+        choices={[
+          // These are the choices that show up in the menu when the user types
+          { id: 123, label: 'foo' },
+          { id: 456, label: 'bar' },
+          { id: 789, label: 'baz' },
+          { id: 1, label: 'study: boston' },
+          { id: 2, label: 'study: nyc' },
+          { id: 3, label: 'study: grand forks' },
+        ]}
+        tags={[
+          { id: 123, label: 'foo' },
+          { id: 456, label: 'bar' },
+        ]}
+        placeholder="Start typing to add a tag"
+        emptyTagsPlaceholder="There are no tags added to this space yet"
+        onCreateNewTag={action('onCreateNewTag')}
+        onAddTag={tag => action('onAddTag')}
+        onRemoveTag={tag => action('onRemoveTag')}
+      />
+    </Fragment>
+  ))

--- a/src/tag-input/styles.scss
+++ b/src/tag-input/styles.scss
@@ -7,8 +7,8 @@
   display: flex;
   flex-direction: column;
   position: relative;
-  z-index: 99999;
 }
+.wrapper.aboveBackdrop { z-index: 99999; }
 
 .tagWrapper {
   display: flex;


### PR DESCRIPTION
![Screen Shot 2019-07-15 at 9 11 20 AM](https://user-images.githubusercontent.com/1704236/61219162-9dfd8200-a6e1-11e9-82da-8828d40f5cf9.png)

By default before, the wrapper div around the control always had a very
large z-index. This meant that it would often be above other controls
when they were opened, which would not be expected. To get around this,
only set the z-index to be large when the control has focus / is open.

Also adds a story for this case.