### PR TITLE
Space picker port, button icon props, and font weight variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 npm-debug.log
 .DS_Store
 dist/
+.*.sw*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "21.5.5",
+  "version": "21.6.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1832,6 +1832,30 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@density/lib-api-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@density/lib-api-types/-/lib-api-types-2.0.1.tgz",
+      "integrity": "sha512-Eax674lRNXXPcjq5DdkCQvl55npoIqlKb39icLO/NWs+otRIrwdLOc8FzWgA9t3Tgm2QPBQOU2z2TDXrb7LaLg==",
+      "dev": true,
+      "requires": {
+        "@density/lib-common-types": "^1.0.2"
+      }
+    },
+    "@density/lib-common-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@density/lib-common-types/-/lib-common-types-1.0.2.tgz",
+      "integrity": "sha512-hPuystN0zCWqHX67Lt6Lvfneu57mbQAs7AlE+Ge6qPtcpEudQKIc0+Ap12mA1hBgEliVwv5qCtkcPqAJYh7pVA==",
+      "dev": true
+    },
+    "@density/lib-space-helpers": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@density/lib-space-helpers/-/lib-space-helpers-0.2.7.tgz",
+      "integrity": "sha512-oYkwc6IPFfUhSj1y4ArX3jZ4VZjGJPPRRPIYee075DF/6PjqZRkkVW4TxQQCXbAMXVLw4c9rZ7DnzqhrxWeUAw==",
+      "dev": true,
+      "requires": {
+        "fuzzy": "^0.1.3"
+      }
+    },
     "@density/node-sass-json-importer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@density/node-sass-json-importer/-/node-sass-json-importer-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "21.5.5",
+  "version": "21.6.0",
   "description": "A UI framework for density projects",
   "scripts": {
     "build-storybook": "build-storybook",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "prop-types": "*",
     "moment": "*",
     "moment-timezone": "*",
-    "regenerator-runtime": "*"
+    "regenerator-runtime": "*",
+    "@density/lib-space-helpers": "*",
+    "@density/lib-api-types": "*"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",
@@ -26,6 +28,8 @@
     "@babel/polyfill": "^7.2.5",
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-react": "^7.0.0",
+    "@density/lib-api-types": "^2.0.1",
+    "@density/lib-space-helpers": "^0.2.7",
     "@density/node-sass-json-importer": "^5.0.0",
     "@storybook/addon-actions": "^5.1.10",
     "@storybook/addon-notes": "^5.1.10",

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import classnames from 'classnames';
 import propTypes from 'prop-types';
 
@@ -33,7 +33,9 @@ type ButtonPropsBase = {
   width?: React.CSSProperties['width']
   height?: React.CSSProperties['height']
   href?: React.HTMLProps<HTMLAnchorElement>['href']
-}
+  leftIcon?: React.ReactNode,
+  rightIcon?: React.ReactNode,
+};
 
 type NativeButtonProps = React.HTMLProps<HTMLButtonElement>;
 
@@ -46,6 +48,8 @@ const Button = React.forwardRef<HTMLElement, ButtonProps>((props, ref) => {
     variant = 'default',
     type = 'primary',
     disabled,
+    leftIcon,
+    rightIcon,
     
     width,
     height,
@@ -54,6 +58,29 @@ const Button = React.forwardRef<HTMLElement, ButtonProps>((props, ref) => {
     children,
     ...otherProps
   } = props;
+
+  let contents = children;
+  if (leftIcon) {
+    contents = (
+      <Fragment>
+        <div className={classnames(styles.icon, styles.left)}>
+          {leftIcon}
+        </div>
+        {contents}
+      </Fragment>
+    );
+  }
+  if (rightIcon) {
+    contents = (
+      <Fragment>
+        {contents}
+        <div className={classnames(styles.icon, styles.right)}>
+          {rightIcon}
+        </div>
+      </Fragment>
+    );
+  }
+
   if (href) {
     return (
       <a
@@ -68,7 +95,7 @@ const Button = React.forwardRef<HTMLElement, ButtonProps>((props, ref) => {
         ref={ref as React.Ref<HTMLAnchorElement>}
         {...(otherProps as any as React.HTMLProps<HTMLAnchorElement>)}
       >
-        {children}
+        {contents}
       </a>
     );
   } else {
@@ -85,7 +112,7 @@ const Button = React.forwardRef<HTMLElement, ButtonProps>((props, ref) => {
         ref={ref as React.Ref<HTMLButtonElement>}
         {...otherProps}
       >
-        {children}
+        {contents}
       </button>
     );
   }

--- a/src/button/story.js
+++ b/src/button/story.js
@@ -88,6 +88,15 @@ storiesOf('Button', module)
   .add('Button with width=100%', () => (
     <Button width="100%">Hello world!</Button>
   ))
+  .add('Button with left icon', () => (
+    <Button leftIcon={<Icons.VisibilityShow />}>More Details</Button>
+  ))
+  .add('Button with right icon', () => (
+    <Button variant="filled" rightIcon={<Icons.Plus />}>Add Device</Button>
+  ))
+  .add('Button with only an icon', () => (
+    <Button leftIcon={<Icons.VisibilityShow />} width={40} />
+  ))
   .add('Small button', () => (
     <Button size="small">Hello world!</Button>
   ))

--- a/src/button/styles.module.scss
+++ b/src/button/styles.module.scss
@@ -41,6 +41,22 @@
   }
 }
 
+.icon {
+  display: inline-block;
+  vertical-align: middle;
+  height: 24px;
+  margin-bottom: 2px;
+}
+.icon.left {
+  transform: translate(-4px, 0px);
+  margin-right: 4px;
+}
+.icon.left:last-child { transform: translate(-9px, 0px); }
+.icon.right {
+  transform: translate(4px, 0px);
+  margin-left: 4px;
+}
+
 .small {
   font-weight: normal;
   height: 24px;

--- a/src/icons/index.tsx
+++ b/src/icons/index.tsx
@@ -478,8 +478,8 @@ for (let iconName in ICONS) {
   ICON_COMPONENTS[iconName].propTypes = {
     color: propTypes.string,
     accentColor: propTypes.string,
-    width: propTypes.number,
-    height: propTypes.number,
+    width: propTypes.oneOfType([propTypes.number, propTypes.string]),
+    height: propTypes.oneOfType([propTypes.number, propTypes.string]),
   };
 
   // Since the name of the function of each component is `IconComponent`, add a name that React will

--- a/src/icons/story.js
+++ b/src/icons/story.js
@@ -28,6 +28,9 @@ storiesOf('Icons', module)
   .add(`A sample icon that's sized smaller`, () => (
     <Icons.ImageUpload width={10} height={10} />
   ))
+  .add(`A sample icon that's sized with percents`, () => (
+    <Icons.ImageUpload width="10%" height="10%" />
+  ))
   .add('All Icons', () => (
     <div style={{
       display: 'grid',

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,11 @@ export { default as Toast, ToastContext } from './toast';
 export { default as Skeleton } from './skeleton';
 export { default as TagInput } from './tag-input';
 export { default as DayOfWeekPicker } from './day-of-week-picker';
+export {
+  default as SpacePicker,
+  SpacePickerDropdown,
+  SpacePickerSelectControlTypes,
+} from './space-picker';
 
 export {
   InputStackGroup,

--- a/src/input-box/index.tsx
+++ b/src/input-box/index.tsx
@@ -18,7 +18,7 @@ export const ANCHOR_RIGHT = 'ANCHOR_RIGHT',
 
 export const InputBoxContext = React.createContext<string | null>(null);
 
-const InputBoxRaw: React.FC<any> = ({leftIcon, forwardedRef, invalid, ...props}) => {
+const InputBoxRaw: React.FC<any> = ({leftIcon, rightIcon, forwardedRef, invalid, ...props}) => {
   const [focused, setFocus] = useState(false);
   const defaultInputRef = useRef();
   const input = forwardedRef || defaultInputRef;
@@ -42,7 +42,8 @@ const InputBoxRaw: React.FC<any> = ({leftIcon, forwardedRef, invalid, ...props})
         className={classnames(styles.inputBox, {
           [styles.inputBoxDisabled]: props.disabled,
           [styles.inputBoxFocused]: focused,
-          [styles.inputBoxContainsIcon]: Boolean(leftIcon),
+          [styles.inputBoxContainsLeftIcon]: Boolean(leftIcon),
+          [styles.inputBoxContainsRightIcon]: Boolean(rightIcon),
           [styles.invalid]: invalid,
         })}
         style={{width: props.width}}
@@ -65,6 +66,7 @@ const InputBoxRaw: React.FC<any> = ({leftIcon, forwardedRef, invalid, ...props})
             if (props.onBlur) { props.onBlur(...args); }
           }}
         />
+        {rightIcon ? <div className={styles.rightIcon}>{rightIcon}</div> : null}
       </div>
     );
   }

--- a/src/input-box/story.js
+++ b/src/input-box/story.js
@@ -20,7 +20,13 @@ storiesOf('InputBox', module)
     <InputBox type="text" leftIcon={<Icon.Search width={18} height={18} />} placeholder="Search" />
   ))
   .add('type=text with text on the left', () => (
-    <InputBox type="text" leftIcon={<span>Text</span>} placeholder="Textbox here" />
+    <InputBox type="text" leftIcon={<span>$</span>} placeholder="Textbox here" />
+  ))
+  .add('type=text with icon on the right', () => (
+    <InputBox type="text" rightIcon={<Icon.Search width={18} height={18} />} placeholder="Search" />
+  ))
+  .add('type=text with text on the right', () => (
+    <InputBox type="text" rightIcon={<span>%</span>} placeholder="Textbox here" />
   ))
   .add('type=text with a forwarded ref to the underlying input used to autofocus', () => {
     const inputRef = React.createRef();

--- a/src/input-box/styles.module.scss
+++ b/src/input-box/styles.module.scss
@@ -43,14 +43,29 @@
   &:-ms-input-placeholder { color: $gray400; }
 }
 
-.inputBoxContainsIcon { padding-left: 16px; }
-.inputBoxContainsIcon input { margin-left: 10px; }
+.inputBoxContainsLeftIcon { padding-left: 16px; }
+.inputBoxContainsLeftIcon input { margin-left: 10px; }
 .leftIcon {
   flex-grow: 0;
   flex-shrink: 0;
   padding-top: 2px;
 }
 .leftIcon svg {
+  padding-top: 3px;
+
+  *[fill-rule=nonzero] {
+    fill: $gray400;
+  }
+}
+
+.inputBoxContainsRightIcon { padding-right: 16px; }
+.inputBoxContainsRightIcon input { margin-right: 10px; }
+.rightIcon {
+  flex-grow: 0;
+  flex-shrink: 0;
+  padding-top: 2px;
+}
+.rightIcon svg {
   padding-top: 3px;
 
   *[fill-rule=nonzero] {

--- a/src/space-picker/index.tsx
+++ b/src/space-picker/index.tsx
@@ -1,0 +1,309 @@
+import React, { useContext, useState, Component, Fragment } from 'react';
+import styles from './styles.module.scss';
+import classnames from 'classnames';
+
+import {
+  Icons,
+  InputBox,
+  AppBar,
+  RadioButton,
+  AppBarContext,
+} from '..';
+import Checkbox from '../checkbox';
+
+import colorVariables from '../../variables/colors.json';
+
+import { spaceHierarchySearcher } from '@density/lib-space-helpers';
+import { DisplaySpaceHierarchyNode } from '@density/lib-space-helpers/types';
+
+export enum SpacePickerSelectControlTypes {
+  RADIOBUTTON = 'RADIOBUTTON',
+  CHECKBOX = 'CHECKBOX',
+  NONE = 'NONE',
+};
+
+type SpacePickerProps = {
+  value: Array<DisplaySpaceHierarchyNode> | Array<string> | DisplaySpaceHierarchyNode | string | null,
+  onChange: (SpaceHierarchyDisplayItem) => any,
+  formattedHierarchy: Array<DisplaySpaceHierarchyNode>,
+
+  showSearchBox?: boolean,
+  searchBoxPlaceholder?: string,
+  placeholder?: string,
+  height?: React.ReactText,
+  canSelectMultiple?: boolean,
+  selectControl?: SpacePickerSelectControlTypes,
+  isItemDisabled?: (SpaceHierarchyDisplayItem) => boolean,
+  onCloseDropdown?: () => void,
+  disabled?: boolean,
+};
+
+function convertValueToSpaceIds(
+  value: Array<DisplaySpaceHierarchyNode> | Array<string> | DisplaySpaceHierarchyNode | string | null,
+  canSelectMultiple: boolean,
+): Array<string> {
+  // Extract the id out of value
+  if (canSelectMultiple) {
+    if (!Array.isArray(value)) {
+      throw new Error('Space Picker value prop is not an array, but `canSelectMultiple` is true! This is not a valid state.');
+    }
+    if (value.length === 0) {
+      return [];
+    } else if (typeof value[0] === 'string') {
+      // An array of ids: ['spc_xxx', 'spx_abc']
+      return value as Array<string>;
+    } else {
+      // An array of formatted hierarchy items:
+      // - [{space: {id: 'spc_xxx', ...}, ...}]
+      return (value as Array<DisplaySpaceHierarchyNode>).map(v => v.space.id);
+    }
+  } else {
+    if (Array.isArray(value)) {
+      throw new Error('Space Picker value prop is an array, but `canSelectMultiple` is false! This is not a valid state.');
+    }
+    if (!value) {
+      // No value is selected
+      return [];
+    } else if (typeof value === 'string') {
+      // A single id: 
+      return [value];
+    } else {
+      // An single formatted hierarchy item:
+      // - {space: {id: 'spc_xxx', ...}, ...}
+      return [value.space.id];
+    }
+  }
+}
+
+export const SpacePickerContext = React.createContext<"CARD_PICKER" | null>(null);
+
+export const SpacePicker: React.FunctionComponent<SpacePickerProps> = ({
+  value,
+  onChange,
+  formattedHierarchy,
+
+  canSelectMultiple=false,
+  isItemDisabled=(s) => false,
+  height,
+  showSearchBox=true,
+  searchBoxPlaceholder=`ex: "New York"`,
+  onCloseDropdown=() => {},
+  selectControl=undefined,
+  disabled=false,
+}) => {
+  const cardPickerContext = useContext(SpacePickerContext) === 'CARD_PICKER';
+  const [searchText, setSearchText] = useState('');
+
+  const selectedSpaceIds = convertValueToSpaceIds(value, canSelectMultiple);
+
+  // The select control is the control to the left of each space that can be clicked to select it.
+  const defaultSelectControl = canSelectMultiple ? SpacePickerSelectControlTypes.CHECKBOX : SpacePickerSelectControlTypes.RADIOBUTTON;
+  selectControl = selectControl || defaultSelectControl;
+
+  if (searchText.length > 0) {
+    formattedHierarchy = spaceHierarchySearcher(formattedHierarchy, searchText);
+  }
+
+  // This function normalizes the difference between when `canSelectMultiple` is set or unset.
+  function callOnChange(item, isChecked) {
+    if (canSelectMultiple) {
+      if (isChecked) {
+        onChange(
+          [...selectedSpaceIds, item.space.id]
+          .map(id => formattedHierarchy.find(h => h.space.id === id))
+        );
+      } else {
+        onChange(
+          selectedSpaceIds
+          .filter(id => id !== item.space.id)
+          .map(id => formattedHierarchy.find(h => h.space.id === id))
+        );
+      }
+    } else {
+      onChange(item);
+    }
+  }
+
+  return (
+    <Fragment>
+      {showSearchBox ? <div className={styles.searchBar} style={{backgroundColor: cardPickerContext ? 'transparent' : undefined}}>
+        <AppBarContext.Provider value={cardPickerContext ? 'TRANSPARENT' : 'NORMAL'}>
+          <AppBar padding={cardPickerContext ? 0 : undefined}>
+            <InputBox
+              type="text"
+              leftIcon={<Icons.Search />}
+              placeholder={searchBoxPlaceholder}
+              width="100%"
+              value={searchText}
+              onChange={e => setSearchText(e.target.value)}
+              disabled={disabled}
+            />
+          </AppBar>
+        </AppBarContext.Provider>
+      </div> : null}
+
+      <div className={styles.scrollContainer} style={{height}}>
+        {formattedHierarchy.map(item => {
+          const spaceDisabled = disabled || !item.space.has_purview || isItemDisabled(item);
+          const isChecked = Boolean(selectedSpaceIds.find(id => id === item.space.id));
+
+          return (
+            <div
+              key={item.space.id}
+              className={classnames(styles.item, `space-type-${item.space.space_type}`, {
+                [styles.depth0]: item.depth === 0,
+                [styles.disabled]: spaceDisabled,
+              })}
+              style={{marginLeft: item.depth * 24, paddingLeft: cardPickerContext ? 0 : undefined}}
+              onMouseUp={e => {
+                if (!spaceDisabled) {
+                  callOnChange(item, !isChecked);
+                }
+                // If only one item can be selected, close the dropdown if this control is in a dropdown.
+                if (!canSelectMultiple) {
+                  onCloseDropdown();
+                }
+              }}
+            >
+              {selectControl === SpacePickerSelectControlTypes.RADIOBUTTON ? (
+                <RadioButton
+                  disabled={spaceDisabled}
+                  checked={isChecked}
+                  onChange={e => {}}
+                />
+              ) : null}
+              {selectControl === SpacePickerSelectControlTypes.CHECKBOX ? (
+                <Checkbox
+                  disabled={spaceDisabled}
+                  checked={isChecked}
+                  color={colorVariables.blue}
+                  onChange={e => {}}
+                />
+              ) : null}
+
+              {item.space.space_type === 'building' ? (
+                <span className={styles.itemIcon}>
+                  <Icons.Building
+                    color={isChecked ? colorVariables.midnight : colorVariables.gray500}
+                  />
+                </span>
+              ) : null}
+              {item.space.space_type === 'floor' ? (
+                <span className={styles.itemIcon}>
+                  <Icons.Floor
+                    color={isChecked ? colorVariables.midnight : colorVariables.gray500}
+                  />
+                </span>
+              ) : null}
+              {item.space.space_type === 'space' && selectControl === SpacePickerSelectControlTypes.NONE ? (
+                <span className={styles.itemIcon} style={{transform: `translate(0, -4px)`}}>
+                  <Icons.L
+                    color={isChecked ? colorVariables.midnight : colorVariables.gray500}
+                  />
+                </span>
+              ) : null}
+
+              <span
+                className={classnames(styles.itemName, {
+                  [styles.bold]: ['campus', 'building', 'floor'].includes(item.space.space_type),
+                  [styles.disabled]: spaceDisabled,
+                  [styles.selected]: selectControl === SpacePickerSelectControlTypes.NONE && isChecked,
+                })}
+              >
+                {item.space.name}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </Fragment>
+  )
+}
+export default SpacePicker;
+
+type SpacePickerDropdownProps = SpacePickerProps & {
+  width?: React.ReactText,
+  dropdownWidth?: React.ReactText;
+};
+
+export class SpacePickerDropdown extends Component<SpacePickerDropdownProps, {opened: boolean}> {
+  state = {
+    opened: false,
+  };
+
+  render() {
+    let {
+      value,
+      placeholder,
+      width,
+      height,
+      dropdownWidth,
+      searchBoxPlaceholder,
+      formattedHierarchy,
+      canSelectMultiple,
+      isItemDisabled,
+      onChange,
+    } = this.props;
+
+    isItemDisabled = typeof isItemDisabled === 'undefined' ? s => false : isItemDisabled;
+    canSelectMultiple = typeof canSelectMultiple === 'undefined' ? false : canSelectMultiple;
+    height = typeof height === 'undefined' ? 256 : height;
+
+    const { opened } = this.state;
+
+    // Calculate a list of space names for all spaces that this space picker has selected
+    const selectedSpaceNames = convertValueToSpaceIds(value, canSelectMultiple)
+      .map(id => formattedHierarchy.find(h => h.space.id === id))
+      .filter(hierarchyItem => typeof hierarchyItem !== 'undefined')
+      .map((hierarchyItem: any) => hierarchyItem.space.name);
+
+    return (
+      <Fragment>
+        <div
+          className={classnames(styles.backdrop, {[styles.visible]: opened})}
+          onClick={() => this.setState({opened: false})}
+        />
+
+        <div className={styles.spacePicker} style={{width}}>
+          <div
+            className={classnames(styles.box, {[styles.focus]: opened})}
+            // When focused, open the select box
+            tabIndex={0}
+            onFocus={e => {
+              e.preventDefault();
+              this.setState({opened: true});
+            }}
+            onMouseDown={() => {
+              this.setState({opened: !opened});
+            }}
+          >
+            {selectedSpaceNames.length > 0 ? (
+              <span>{selectedSpaceNames.length > 1 ? `${selectedSpaceNames.length} spaces selected` : selectedSpaceNames[0]}</span>
+            ) : (
+              <span className={styles.placeholder}>
+                {placeholder || `No ${canSelectMultiple ? 'spaces' : 'space'} selected`}
+              </span>
+            )}
+            <span className={classnames(styles.chevron)}>
+              <Icons.ChevronDown color={colorVariables.gray700} />
+            </span>
+          </div>
+
+            <div className={classnames(styles.popup, {[styles.visible]: opened})} style={{width: dropdownWidth}}>
+              <SpacePicker
+                value={value}
+                onChange={onChange}
+
+                searchBoxPlaceholder={searchBoxPlaceholder}
+                formattedHierarchy={formattedHierarchy}
+                canSelectMultiple={canSelectMultiple}
+                isItemDisabled={isItemDisabled}
+                height={height}
+                onCloseDropdown={() => this.setState({opened: false})}
+              />
+            </div>
+        </div>
+      </Fragment>
+    );
+  }
+}

--- a/src/space-picker/story.js
+++ b/src/space-picker/story.js
@@ -1,0 +1,1110 @@
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import SpacePicker, { SpacePickerContext, SpacePickerDropdown } from './';
+import { spaceHierarchyFormatter } from '@density/lib-space-helpers';
+
+const hierarchy = [
+  {
+    "id": "spc_768300163184722233",
+    "name": "Ames, IA",
+    "has_purview": true,
+    "space_type": "campus",
+    "daily_reset": "04:00:00",
+    "inherits_time_segments": false,
+    "time_segments": [
+      {
+        "id": "tsm_770768406717661950",
+        "label": "Meeting Hours",
+        "start": "09:00:00",
+        "end": "17:00:00",
+        "days": [
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday"
+        ]
+      }
+    ],
+    "capacity": null,
+    "children": [
+      {
+        "id": "spc_768300251122499898",
+        "name": "Ames HQ",
+        "has_purview": true,
+        "space_type": "building",
+        "daily_reset": "04:00:00",
+        "inherits_time_segments": false,
+        "time_segments": [
+          {
+            "id": "tsm_771796034744484059",
+            "label": "Working Hours",
+            "start": "08:00:00",
+            "end": "17:00:00",
+            "days": [
+              "Monday",
+              "Tuesday",
+              "Wednesday",
+              "Thursday",
+              "Friday"
+            ]
+          }
+        ],
+        "capacity": 1400,
+        "children": [
+          {
+            "id": "spc_768300356001071420",
+            "name": "1st Floor",
+            "has_purview": true,
+            "space_type": "floor",
+            "daily_reset": "04:00:00",
+            "inherits_time_segments": true,
+            "time_segments": [],
+            "capacity": 600
+          },
+          {
+            "id": "spc_768300388121051453",
+            "name": "2nd Floor",
+            "has_purview": true,
+            "space_type": "floor",
+            "daily_reset": "04:00:00",
+            "inherits_time_segments": true,
+            "time_segments": [],
+            "capacity": 600,
+            "children": [
+              {
+                "id": "spc_768301526455157073",
+                "name": "Room 202",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 4
+              },
+              {
+                "id": "spc_768301566217158994",
+                "name": "Room 203",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 4
+              },
+              {
+                "id": "spc_768301615210824021",
+                "name": "Room 204",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 4
+              },
+              {
+                "id": "spc_768301647959949654",
+                "name": "Room 205",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 4
+              },
+              {
+                "id": "spc_768301688590172504",
+                "name": "Room 206",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 12
+              },
+              {
+                "id": "spc_768301730193473881",
+                "name": "Room 207",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 12
+              },
+              {
+                "id": "spc_768301764687429978",
+                "name": "Room 208",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 10
+              },
+              {
+                "id": "spc_772149685077934886",
+                "name": "Room 209",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": null
+              },
+              {
+                "id": "spc_772150609955521386",
+                "name": "Room 210",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": null
+              },
+              {
+                "id": "spc_768301482339467598",
+                "name": "Womens Room",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 4
+              }
+            ]
+          },
+          {
+            "id": "spc_768921812707835978",
+            "name": "3rd Floor",
+            "has_purview": true,
+            "space_type": "floor",
+            "daily_reset": "04:00:00",
+            "inherits_time_segments": true,
+            "time_segments": [],
+            "capacity": 600,
+            "children": [
+              {
+                "id": "spc_768922340200284248",
+                "name": "Neighborhood A: Sales",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 24
+              },
+              {
+                "id": "spc_768922386639618138",
+                "name": "Neighborhood B: Engineering",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 24
+              },
+              {
+                "id": "spc_768922429685760091",
+                "name": "Neighborhood C: Finance & Engineering",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 24
+              },
+              {
+                "id": "spc_768922483691618398",
+                "name": "Neighborhood D: Marketing",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 20
+              }
+            ]
+          },
+          {
+            "id": "spc_768300469201142081",
+            "name": "4th Floor",
+            "has_purview": true,
+            "space_type": "floor",
+            "daily_reset": "04:00:00",
+            "inherits_time_segments": true,
+            "time_segments": [],
+            "capacity": 600,
+            "children": [
+              {
+                "id": "spc_768300930276786505",
+                "name": "All Star Cafe",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 600
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "spc_733498787296706930",
+    "name": "Dallas Campus",
+    "has_purview": true,
+    "space_type": "campus",
+    "daily_reset": "04:00:00",
+    "inherits_time_segments": false,
+    "time_segments": [
+      {
+        "id": "tsm_733498787930046835",
+        "label": "Working Hours",
+        "start": "08:00:00",
+        "end": "17:00:00",
+        "days": [
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday"
+        ]
+      }
+    ],
+    "capacity": null,
+    "children": [
+      {
+        "id": "spc_733499665273586383",
+        "name": "208 N Market St",
+        "has_purview": true,
+        "space_type": "building",
+        "daily_reset": "04:00:00",
+        "inherits_time_segments": false,
+        "time_segments": [
+          {
+            "id": "tsm_771796452899815652",
+            "label": "Working Hours",
+            "start": "08:00:00",
+            "end": "17:00:00",
+            "days": [
+              "Monday",
+              "Tuesday",
+              "Wednesday",
+              "Thursday",
+              "Friday"
+            ]
+          }
+        ],
+        "capacity": 120,
+        "children": [
+          {
+            "id": "spc_733499844055794618",
+            "name": "Market St - 1st Floor",
+            "has_purview": true,
+            "space_type": "floor",
+            "daily_reset": "04:00:00",
+            "inherits_time_segments": true,
+            "time_segments": [],
+            "capacity": 100,
+            "children": [
+              {
+                "id": "spc_733505322513072884",
+                "name": "Neighborhood: Marketing",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 80
+              },
+              {
+                "id": "spc_733505397159101274",
+                "name": "Neighborhood: Sales",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 40
+              },
+              {
+                "id": "spc_733505198793687633",
+                "name": "Open Seating Area",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 90
+              }
+            ]
+          },
+          {
+            "id": "spc_733499883742299114",
+            "name": "Market St - 2nd Floor",
+            "has_purview": true,
+            "space_type": "floor",
+            "daily_reset": "04:00:00",
+            "inherits_time_segments": true,
+            "time_segments": [],
+            "capacity": 100,
+            "children": [
+              {
+                "id": "spc_733736844365136486",
+                "name": "All Conference Rooms",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": null
+              },
+              {
+                "id": "spc_733505838727037297",
+                "name": "Conference Room A",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 8
+              },
+              {
+                "id": "spc_733505915189199324",
+                "name": "Conference Room B",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 10
+              },
+              {
+                "id": "spc_733506001277289013",
+                "name": "Conference Room C",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 16
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "spc_751933880029675548",
+        "name": "2550 Pacific Ave",
+        "has_purview": true,
+        "space_type": "building",
+        "daily_reset": "04:00:00",
+        "inherits_time_segments": false,
+        "time_segments": [
+          {
+            "id": "tsm_771796511255167207",
+            "label": "Working Hours",
+            "start": "08:00:00",
+            "end": "17:00:00",
+            "days": [
+              "Monday",
+              "Tuesday",
+              "Wednesday",
+              "Thursday",
+              "Friday"
+            ]
+          }
+        ],
+        "capacity": 180,
+        "children": [
+          {
+            "id": "spc_751935846910787967",
+            "name": "Pacific Ave - 3rd Floor",
+            "has_purview": true,
+            "space_type": "floor",
+            "daily_reset": "04:00:00",
+            "inherits_time_segments": true,
+            "time_segments": [],
+            "capacity": null,
+            "children": [
+              {
+                "id": "spc_751936271760228393",
+                "name": "Large Open Office",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 162
+              },
+              {
+                "id": "spc_751937353534145323",
+                "name": "Open Area: Engineering",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 130
+              },
+              {
+                "id": "spc_751936546352923102",
+                "name": "Small Open Office",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 110
+              }
+            ]
+          },
+          {
+            "id": "spc_751935903529697760",
+            "name": "Pacific Ave - 4th Floor",
+            "has_purview": true,
+            "space_type": "floor",
+            "daily_reset": "04:00:00",
+            "inherits_time_segments": true,
+            "time_segments": [],
+            "capacity": null,
+            "children": [
+              {
+                "id": "spc_751937840664805938",
+                "name": "Conference Room 4-A",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 12
+              },
+              {
+                "id": "spc_751937908620919445",
+                "name": "Conference Room 4-B",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 14
+              },
+              {
+                "id": "spc_751938015944770376",
+                "name": "Conference Room 4-C",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 15
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "spc_733501182353343413",
+    "name": "NYC Campus",
+    "has_purview": true,
+    "space_type": "campus",
+    "daily_reset": "04:00:00",
+    "inherits_time_segments": false,
+    "time_segments": [
+      {
+        "id": "tsm_733501182714053560",
+        "label": "Working Hours",
+        "start": "08:00:00",
+        "end": "17:00:00",
+        "days": [
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday"
+        ]
+      }
+    ],
+    "capacity": null,
+    "children": [
+      {
+        "id": "spc_733501529398444428",
+        "name": "5 Hanover Square",
+        "has_purview": true,
+        "space_type": "building",
+        "daily_reset": "04:00:00",
+        "inherits_time_segments": false,
+        "time_segments": [
+          {
+            "id": "tsm_771796576375931117",
+            "label": "Working Hours",
+            "start": "08:00:00",
+            "end": "17:00:00",
+            "days": [
+              "Monday",
+              "Tuesday",
+              "Wednesday",
+              "Thursday",
+              "Friday"
+            ]
+          }
+        ],
+        "capacity": 100,
+        "children": [
+          {
+            "id": "spc_733501805211681563",
+            "name": "Floor 17",
+            "has_purview": true,
+            "space_type": "floor",
+            "daily_reset": "04:00:00",
+            "inherits_time_segments": true,
+            "time_segments": [],
+            "capacity": 100,
+            "children": [
+              {
+                "id": "spc_733541930868146711",
+                "name": "Skyline Cafe",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": false,
+                "time_segments": [
+                  {
+                    "id": "tsm_764206462787387773",
+                    "label": "Dinner",
+                    "start": "15:00:00",
+                    "end": "20:00:00",
+                    "days": [
+                      "Monday",
+                      "Tuesday",
+                      "Wednesday",
+                      "Thursday",
+                      "Friday"
+                    ]
+                  },
+                  {
+                    "id": "tsm_764206462942577023",
+                    "label": "Breakfast",
+                    "start": "08:00:00",
+                    "end": "11:00:00",
+                    "days": [
+                      "Monday",
+                      "Tuesday",
+                      "Wednesday",
+                      "Thursday",
+                      "Friday"
+                    ]
+                  },
+                  {
+                    "id": "tsm_764206462950965632",
+                    "label": "Lunch",
+                    "start": "11:00:00",
+                    "end": "15:00:00",
+                    "days": [
+                      "Monday",
+                      "Tuesday",
+                      "Wednesday",
+                      "Thursday",
+                      "Friday"
+                    ]
+                  }
+                ],
+                "capacity": 156
+              }
+            ]
+          },
+          {
+            "id": "spc_733501838942274383",
+            "name": "Floor 18",
+            "has_purview": true,
+            "space_type": "floor",
+            "daily_reset": "04:00:00",
+            "inherits_time_segments": true,
+            "time_segments": [],
+            "capacity": 50,
+            "children": [
+              {
+                "id": "spc_733542457312018435",
+                "name": "Tip-Top Cafe",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": false,
+                "time_segments": [
+                  {
+                    "id": "tsm_764206719025807508",
+                    "label": "Dinner",
+                    "start": "15:00:00",
+                    "end": "20:00:00",
+                    "days": [
+                      "Monday",
+                      "Tuesday",
+                      "Wednesday",
+                      "Thursday",
+                      "Friday"
+                    ]
+                  },
+                  {
+                    "id": "tsm_764206719021613203",
+                    "label": "Working Hours",
+                    "start": "08:00:00",
+                    "end": "17:00:00",
+                    "days": [
+                      "Monday",
+                      "Tuesday",
+                      "Wednesday",
+                      "Thursday",
+                      "Friday"
+                    ]
+                  },
+                  {
+                    "id": "tsm_764206719030001813",
+                    "label": "Breakfast",
+                    "start": "08:00:00",
+                    "end": "11:00:00",
+                    "days": [
+                      "Monday",
+                      "Tuesday",
+                      "Wednesday",
+                      "Thursday",
+                      "Friday"
+                    ]
+                  },
+                  {
+                    "id": "tsm_764206719042584726",
+                    "label": "Lunch",
+                    "start": "11:00:00",
+                    "end": "15:00:00",
+                    "days": [
+                      "Monday",
+                      "Tuesday",
+                      "Wednesday",
+                      "Thursday",
+                      "Friday"
+                    ]
+                  }
+                ],
+                "capacity": 130
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "spc_755956453121982691",
+    "name": "San Francisco Campus",
+    "has_purview": true,
+    "space_type": "campus",
+    "daily_reset": "04:00:00",
+    "inherits_time_segments": false,
+    "time_segments": [],
+    "capacity": null,
+    "children": [
+      {
+        "id": "spc_755956609447887356",
+        "name": "Main Building",
+        "has_purview": true,
+        "space_type": "building",
+        "daily_reset": "04:00:00",
+        "inherits_time_segments": false,
+        "time_segments": [
+          {
+            "id": "tsm_771796757800550642",
+            "label": "Working Hours",
+            "start": "08:00:00",
+            "end": "17:00:00",
+            "days": [
+              "Monday",
+              "Tuesday",
+              "Wednesday",
+              "Thursday",
+              "Friday"
+            ]
+          }
+        ],
+        "capacity": 100,
+        "children": [
+          {
+            "id": "spc_755956662870737490",
+            "name": "1st Floor",
+            "has_purview": true,
+            "space_type": "floor",
+            "daily_reset": "04:00:00",
+            "inherits_time_segments": true,
+            "time_segments": [],
+            "capacity": null,
+            "children": [
+              {
+                "id": "spc_755956844278580074",
+                "name": "Room 101",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 15
+              },
+              {
+                "id": "spc_755956958443339851",
+                "name": "Room 102",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 55
+              }
+            ]
+          },
+          {
+            "id": "spc_755956688820896381",
+            "name": "2nd Floor",
+            "has_purview": true,
+            "space_type": "floor",
+            "daily_reset": "04:00:00",
+            "inherits_time_segments": true,
+            "time_segments": [],
+            "capacity": null,
+            "children": [
+              {
+                "id": "spc_755957174638739931",
+                "name": "Room 201",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 100
+              }
+            ]
+          },
+          {
+            "id": "spc_755956721951703719",
+            "name": "3rd Floor",
+            "has_purview": true,
+            "space_type": "floor",
+            "daily_reset": "04:00:00",
+            "inherits_time_segments": true,
+            "time_segments": [],
+            "capacity": null,
+            "children": [
+              {
+                "id": "spc_755957309313647343",
+                "name": "Room 301",
+                "has_purview": true,
+                "space_type": "space",
+                "daily_reset": "04:00:00",
+                "inherits_time_segments": true,
+                "time_segments": [],
+                "capacity": 8
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "spc_764201534631183287",
+    "name": "Test Office Building",
+    "has_purview": true,
+    "space_type": "building",
+    "daily_reset": "04:00:00",
+    "inherits_time_segments": false,
+    "time_segments": [
+      {
+        "id": "tsm_764201535440683962",
+        "label": "Weekend Office Hours",
+        "start": "12:00:00",
+        "end": "16:00:00",
+        "days": [
+          "Sunday",
+          "Saturday"
+        ]
+      },
+      {
+        "id": "tsm_764201535444878267",
+        "label": "Working Hours",
+        "start": "08:00:00",
+        "end": "17:00:00",
+        "days": [
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday"
+        ]
+      }
+    ],
+    "capacity": 1800,
+    "children": [
+      {
+        "id": "spc_764201910176579700",
+        "name": "Floor 2",
+        "has_purview": true,
+        "space_type": "floor",
+        "daily_reset": "04:00:00",
+        "inherits_time_segments": true,
+        "time_segments": [],
+        "capacity": null,
+        "children": [
+          {
+            "id": "spc_764202047997215230",
+            "name": "Test Conference Room A",
+            "has_purview": true,
+            "space_type": "space",
+            "daily_reset": "04:00:00",
+            "inherits_time_segments": true,
+            "time_segments": [],
+            "capacity": 10
+          }
+        ]
+      },
+      {
+        "id": "spc_764201760695779977",
+        "name": "Test Lobby",
+        "has_purview": true,
+        "space_type": "space",
+        "daily_reset": "04:00:00",
+        "inherits_time_segments": true,
+        "time_segments": [],
+        "capacity": null
+      }
+    ]
+  },
+  {
+    "id": "spc_768187563067310387",
+    "name": "Test Office Building - San Francisco",
+    "has_purview": true,
+    "space_type": "building",
+    "daily_reset": "04:00:00",
+    "inherits_time_segments": false,
+    "time_segments": [],
+    "capacity": null
+  }
+];
+const formattedHierarchy = spaceHierarchyFormatter(hierarchy);
+
+storiesOf('SpacePicker/Regular Space Picker', module)
+  .add('Default Space Picker', () => {
+    function Wrapper() {
+      const [ selected, setSelected ] = useState(null);
+      return (
+        <SpacePicker
+          value={selected}
+          onChange={setSelected}
+          formattedHierarchy={formattedHierarchy}
+        />
+      );
+    }
+
+    return (
+      <div style={{width: 300, height: 300, margin: '100px auto'}}>
+        <Wrapper />
+      </div>
+    );
+  })
+  .add('Space Picker: without search box', () => {
+    function Wrapper() {
+      const [ selected, setSelected ] = useState(null);
+      return (
+        <SpacePicker
+          value={selected}
+          onChange={setSelected}
+          formattedHierarchy={formattedHierarchy}
+          showSearchBox={false}
+        />
+      );
+    }
+
+    return (
+      <div style={{width: 300, height: 300, margin: '100px auto'}}>
+        <Wrapper />
+      </div>
+    );
+  })
+  .add('Space Picker: with ability to select multiple items', () => {
+    function Wrapper() {
+      const [ selected, setSelected ] = useState([]);
+      return (
+        <SpacePicker
+          value={selected}
+          onChange={setSelected}
+          formattedHierarchy={formattedHierarchy}
+          canSelectMultiple={true}
+        />
+      );
+    }
+
+    return (
+      <div style={{width: 300, height: 300, margin: '100px auto'}}>
+        <Wrapper />
+      </div>
+    );
+  })
+  .add('Space Picker: with all buildings disabled', () => {
+    function Wrapper() {
+      const [ selected, setSelected ] = useState(null);
+      return (
+        <SpacePicker
+          value={selected}
+          onChange={setSelected}
+          formattedHierarchy={formattedHierarchy}
+          isItemDisabled={i => i.space.space_type === 'building'}
+        />
+      );
+    }
+
+    return (
+      <div style={{width: 300, height: 300, margin: '100px auto'}}>
+        <Wrapper />
+      </div>
+    );
+  })
+  .add('Space Picker: with custom search placeholder', () => {
+    function Wrapper() {
+      const [ selected, setSelected ] = useState(null);
+      return (
+        <SpacePicker
+          value={selected}
+          onChange={setSelected}
+          formattedHierarchy={formattedHierarchy}
+          searchBoxPlaceholder="Custom placeholder"
+        />
+      );
+    }
+
+    return (
+      <div style={{width: 300, height: 300, margin: '100px auto'}}>
+        <Wrapper />
+      </div>
+    );
+  })
+  .add('Space Picker: with whole control disabled', () => {
+    function Wrapper() {
+      const [ selected, setSelected ] = useState(null);
+      return (
+        <SpacePicker
+          value={selected}
+          onChange={setSelected}
+          formattedHierarchy={formattedHierarchy}
+          disabled={true}
+        />
+      );
+    }
+
+    return (
+      <div style={{width: 300, height: 300, margin: '100px auto'}}>
+        <Wrapper />
+      </div>
+    );
+  })
+  .add('Space Picker: with "CARD_PICKER" context', () => {
+    function Wrapper() {
+      const [ selected, setSelected ] = useState(null);
+      return (
+        <SpacePickerContext.Provider value="CARD_PICKER">
+          <SpacePicker
+            value={selected}
+            onChange={setSelected}
+            formattedHierarchy={formattedHierarchy}
+            searchBoxPlaceholder="Custom placeholder"
+          />
+        </SpacePickerContext.Provider>
+      );
+    }
+
+    return (
+      <div style={{width: 300, height: 300, margin: '100px auto'}}>
+        <p>This context has no padding on either side, as well as a transparent background.</p>
+        <Wrapper />
+      </div>
+    );
+  })
+
+storiesOf('SpacePicker/Dropdown Space Picker', module)
+  .add('Dropdown Space Picker', () => {
+    function Wrapper() {
+      const [ selected, setSelected ] = useState(null);
+      return (
+        <SpacePickerDropdown
+          value={selected}
+          onChange={setSelected}
+          formattedHierarchy={formattedHierarchy}
+        />
+      );
+    }
+
+    return (
+      <div style={{width: 300, height: 300, margin: '100px auto'}}>
+        <Wrapper />
+      </div>
+    );
+  })
+  .add('Dropdown Space Picker: with custom dropdown width', () => {
+    function Wrapper() {
+      const [ selected, setSelected ] = useState(null);
+      return (
+        <SpacePickerDropdown
+          value={selected}
+          onChange={setSelected}
+          formattedHierarchy={formattedHierarchy}
+          width="100%"
+        />
+      );
+    }
+
+    return (
+      <div style={{width: 300, height: 300, margin: '100px auto'}}>
+        <Wrapper />
+      </div>
+    );
+  })
+  .add('Dropdown Space Picker: with custom dropdown placeholder', () => {
+    function Wrapper() {
+      const [ selected, setSelected ] = useState(null);
+      return (
+        <SpacePickerDropdown
+          value={selected}
+          onChange={setSelected}
+          formattedHierarchy={formattedHierarchy}
+          width="100%"
+          placeholder="Custom placeholder"
+        />
+      );
+    }
+
+    return (
+      <div style={{width: 300, height: 300, margin: '100px auto'}}>
+        <Wrapper />
+      </div>
+    );
+  })
+  .add('Dropdown Space Picker: with multiple select', () => {
+    function Wrapper() {
+      const [ selected, setSelected ] = useState([]);
+      return (
+        <SpacePickerDropdown
+          value={selected}
+          onChange={setSelected}
+          formattedHierarchy={formattedHierarchy}
+          canSelectMultiple={true}
+        />
+      );
+    }
+
+    return (
+      <div style={{width: 300, height: 300, margin: '100px auto'}}>
+        <Wrapper />
+      </div>
+    );
+  })

--- a/src/space-picker/styles.module.scss
+++ b/src/space-picker/styles.module.scss
@@ -1,0 +1,123 @@
+@import "../../variables/colors.scss";
+@import "../../variables/spacing.scss";
+@import "../../variables/fonts.scss";
+
+.spacePicker {
+  position: relative;
+  width: 200px;
+}
+
+.box {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  box-sizing: border-box;
+
+  width: 100%;
+  height: 40px;
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-bottom: 3px;
+  border: 1px solid $gray300;
+  border-radius: $borderRadiusBase;
+  background-color: #fff;
+  font-family: $fontBase;
+  cursor: pointer;
+  color: $gray700;
+  user-select: none;
+  transition: all 100ms ease-in-out;
+  outline: none;
+}
+
+.box.focus { border-color: $blue; }
+
+.placeholder { color: $inputFieldPlaceholderColor; }
+
+.popup {
+  position: absolute;
+  top: 50px;
+  padding-left: 0px;
+  padding-right: 0px;
+
+  width: 368px;
+
+  z-index: 999999;
+  color: $midnight;
+  background-color: $white;
+  box-shadow: 0px 2px 4px rgba($gray900, 0.1);
+  box-sizing: border-box;
+  border: 1px solid $gray200;
+  border-radius: $borderRadiusBase;
+  transition: all 100ms ease-in-out;
+  user-select: none;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+
+  // When opened, fade in the select box and enable pointer events.
+  // NOTE: when the select box is closed, it isn't given `display: none`, because giving it that
+  // would make the animation difficult. Instead, it's given `pointer-events: none`, which causes
+  // any clicks to not occur on that element and instead be handled by the element underneath it.
+  opacity: 0;
+  pointer-events: none;
+}
+.popup.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.chevron {
+  transform: translate(5px, 3px);
+}
+
+.backdrop {
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  display: none;
+}
+.backdrop.visible { display: block; }
+
+
+
+.searchBar {
+  background-color: $white;
+}
+
+.scrollContainer {
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  height: calc(100% - 64px - 64px - 64px);
+  height: 100%;
+}
+.item {
+  display: flex;
+  align-items: center;
+  height: 40px;
+  padding-left: 24px;
+  padding-right: 24px;
+  color: $gray700;
+  cursor: pointer;
+  user-select: none;
+}
+.item.depth0 { border-top: 1px solid $gray200; }
+.item.depth0:first-child { border-top-width: 0px; }
+.item.disabled { cursor: default; color: $gray400; }
+
+.itemIcon { margin-left: 8px; }
+
+.itemName {
+  margin-left: 8px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.itemName.selected {
+  color: $blue;
+  font-weight: 500;
+}
+.copyFromSpaceModalItemName.bold { font-weight: bold; }
+.copyFromSpaceModalItemName.disabled {
+  color: $gray400;
+}

--- a/variables/fonts.json
+++ b/variables/fonts.json
@@ -22,5 +22,9 @@
   "fontSizeSmall": 12,
   "fontSizeBase": 14,
   "fontSizeLarge": 16,
-  "fontSizeXLarge": 24
+  "fontSizeXLarge": 24,
+
+  "fontWeightNormal": "normal",
+  "fontWeightMedium": 500,
+  "fontWeightBold": "bold"
 }

--- a/variables/fonts.scss
+++ b/variables/fonts.scss
@@ -19,3 +19,7 @@ $fontSizeSmall: 12px;
 $fontSizeBase: 16px;
 $fontSizeLarge: 18px;
 $fontSizeXLarge: 24px;
+
+$fontWeightNormal: normal;
+$fontWeightMedium: 500;
+$fontWeightBold: bold;


### PR DESCRIPTION
- Port over the space picker from the dashboard
- Add a new `leftIcon` and `rightIcon` props to the button so that an icon can be rendered on the left and right of a button. This works similarly to the existing `leftIcon` prop on the `InputBox`, and matches the styling of the most up to date sketch density ui button placement:
![Screen Shot 2020-06-12 at 11 25 29 AM](https://user-images.githubusercontent.com/1704236/84518986-7622ef80-ac9f-11ea-8a84-6273d6ee07c7.png)
![Screen Shot 2020-06-12 at 11 25 35 AM](https://user-images.githubusercontent.com/1704236/84518987-76bb8600-ac9f-11ea-9ef6-e9019fe98ed3.png)
- Adds some new font variables that define font weights. I pushed for this a while back when the the colors were redone, but it was forgotten about. I don't think this is controversial though.

**NOTE: The package version still needs to be updated.**