### PR TITLE
Dialogs, and Toaster / Dialogger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "21.7.1",
+  "version": "21.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "21.7.1",
+  "version": "21.8.0",
   "description": "A UI framework for density projects",
   "scripts": {
     "build-storybook": "build-storybook",

--- a/src/dialog/index.tsx
+++ b/src/dialog/index.tsx
@@ -1,0 +1,182 @@
+import React, { useRef, useEffect, useState } from 'react';
+import classnames from 'classnames';
+import styles from './styles.module.scss';
+
+import {
+  AppBar,
+  AppBarTitle,
+  AppBarSection,
+  AppBarContext,
+  ButtonGroup,
+  Button,
+  Modal,
+  InputBox,
+} from '..';
+
+type DialogBaseProps = {
+  // From modal
+  visible: boolean,
+  width?: React.ReactText,
+  height?: React.ReactText,
+};
+
+// ----------------------------------------------------------------------------
+// ALERT DIALOG
+// ----------------------------------------------------------------------------
+type AlertDialogProps = DialogBaseProps & {
+  prompt: React.ReactNode,
+  onSubmit: () => void,
+
+  title?: React.ReactNode,
+  confirmText?: React.ReactNode,
+};
+
+export const AlertDialog: React.FunctionComponent<AlertDialogProps> = ({title, prompt, confirmText, onSubmit, ...modalProps}) => (
+  <Modal width={480} {...modalProps} onBlur={onSubmit} onEscape={onSubmit}>
+    <div className={styles.dialogConfirm}>
+      <AppBar>
+        <AppBarTitle>{title || 'Alert'}</AppBarTitle>
+      </AppBar>
+      <div className={styles.dialogConfirmContent}>
+        {prompt}
+      </div>
+      <AppBarContext.Provider value="BOTTOM_ACTIONS">
+        <AppBar>
+          <AppBarSection />
+          <AppBarSection>
+            <ButtonGroup>
+              <Button
+                variant="filled"
+                type="primary"
+                onClick={() => onSubmit()}
+              >
+                {confirmText || 'OK'}
+              </Button>
+            </ButtonGroup>
+          </AppBarSection>
+        </AppBar>
+      </AppBarContext.Provider>
+    </div>
+  </Modal>
+);
+AlertDialog.displayName = 'AlertDialog';
+
+// ----------------------------------------------------------------------------
+// CONFIRM DIALOG
+// ----------------------------------------------------------------------------
+type ConfirmDialogProps = DialogBaseProps & {
+  prompt: React.ReactNode,
+  onSubmit: () => void,
+  onDismiss: () => void,
+
+  title?: React.ReactNode,
+  confirmText?: React.ReactNode,
+};
+
+export const ConfirmDialog: React.FunctionComponent<ConfirmDialogProps> = ({title, prompt, confirmText, onSubmit, onDismiss, ...modalProps}) => (
+  <Modal width={480} {...modalProps} onBlur={onDismiss} onEscape={onDismiss}>
+    <div className={styles.dialogConfirm}>
+      <AppBar>
+        <AppBarTitle>{title || 'Confirm'}</AppBarTitle>
+      </AppBar>
+      <div className={styles.dialogConfirmContent}>
+        {prompt}
+      </div>
+      <AppBarContext.Provider value="BOTTOM_ACTIONS">
+        <AppBar>
+          <AppBarSection />
+          <AppBarSection>
+            <ButtonGroup>
+              <Button variant="underline" onClick={onDismiss}>Cancel</Button>
+              <Button
+                variant="filled"
+                type="primary"
+                onClick={() => onSubmit()}
+              >
+                {confirmText || 'Confirm'}
+              </Button>
+            </ButtonGroup>
+          </AppBarSection>
+        </AppBar>
+      </AppBarContext.Provider>
+    </div>
+  </Modal>
+);
+ConfirmDialog.displayName = 'ConfirmDialog';
+
+// ----------------------------------------------------------------------------
+// PROMPT DIALOG
+// ----------------------------------------------------------------------------
+type PromptDialogProps = DialogBaseProps & {
+  prompt: React.ReactNode,
+  onSubmit: (text: string) => void,
+  onDismiss: () => void,
+
+  title?: React.ReactNode,
+  placeholder?: React.ReactNode,
+  leftIcon?: React.ReactNode,
+  rightIcon?: React.ReactNode,
+  confirmText?: React.ReactNode,
+};
+
+export const PromptDialog: React.FunctionComponent<PromptDialogProps> = ({title, prompt, confirmText, onSubmit, onDismiss, placeholder, leftIcon, rightIcon, ...modalProps}) => {
+  const [ text, setText ] = useState('');
+
+  // When a prompt is shown, auto focus its text box.
+  const textBoxRef = useRef(null);
+  useEffect(() => {
+    if (textBoxRef && textBoxRef.current) {
+      (textBoxRef as any).current.focus();
+    }
+  }, [modalProps.visible, textBoxRef]);
+
+  return (
+    <Modal width={480} {...modalProps} onBlur={onDismiss} onEscape={onDismiss}>
+      <div className={styles.dialogPrompt}>
+        <AppBar>
+          <AppBarTitle>{title || 'Prompt'}</AppBarTitle>
+        </AppBar>
+        <div className={styles.dialogPromptContent}>
+          {prompt ? (
+            <div className={styles.dialogPromptLabel}>
+              {prompt}
+            </div>
+          ) : null}
+          <InputBox
+            type="text"
+            value={text || ''}
+            onChange={e => setText(e.target.value)}
+            placeholder={placeholder}
+            leftIcon={leftIcon}
+            rightIcon={rightIcon}
+            width="100%"
+            onKeyDown={e => {
+              if (e.key === 'Enter') {
+                onSubmit(text);
+              }
+            }}
+            ref={textBoxRef}
+          />
+        </div>
+        <AppBarContext.Provider value="BOTTOM_ACTIONS">
+          <AppBar>
+            <AppBarSection></AppBarSection>
+            <AppBarSection>
+              <ButtonGroup>
+                <Button variant="underline" onClick={onDismiss}>Cancel</Button>
+                <Button
+                  variant="filled"
+                  type="primary"
+                  onClick={() => onSubmit(text)}
+                >
+                  {confirmText || 'Submit'}
+                </Button>
+              </ButtonGroup>
+            </AppBarSection>
+          </AppBar>
+        </AppBarContext.Provider>
+      </div>
+    </Modal>
+  );
+};
+PromptDialog.displayName = 'PromptDialog';

--- a/src/dialog/index.tsx
+++ b/src/dialog/index.tsx
@@ -31,11 +31,17 @@ export type AlertDialogProps = DialogBaseProps & {
   confirmText?: React.ReactNode,
 };
 
-export const AlertDialog: React.FunctionComponent<AlertDialogProps> = ({title, prompt, confirmText, onSubmit, ...modalProps}) => (
+export const AlertDialog: React.FunctionComponent<AlertDialogProps> = ({
+  title='Alert',
+  prompt,
+  confirmText='OK',
+  onSubmit,
+  ...modalProps
+}) => (
   <Modal width={480} {...modalProps} onBlur={onSubmit} onEscape={onSubmit}>
     <div className={styles.dialogConfirm}>
       <AppBar>
-        <AppBarTitle>{title || 'Alert'}</AppBarTitle>
+        <AppBarTitle>{title}</AppBarTitle>
       </AppBar>
       <div className={styles.dialogConfirmContent}>
         {prompt}
@@ -50,7 +56,7 @@ export const AlertDialog: React.FunctionComponent<AlertDialogProps> = ({title, p
                 type="primary"
                 onClick={() => onSubmit()}
               >
-                {confirmText || 'OK'}
+                {confirmText}
               </Button>
             </ButtonGroup>
           </AppBarSection>
@@ -74,11 +80,19 @@ export type ConfirmDialogProps = DialogBaseProps & {
   cancelText?: React.ReactNode,
 };
 
-export const ConfirmDialog: React.FunctionComponent<ConfirmDialogProps> = ({title, prompt, confirmText, cancelText, onSubmit, onDismiss, ...modalProps}) => (
+export const ConfirmDialog: React.FunctionComponent<ConfirmDialogProps> = ({
+  title="Confirm",
+  prompt,
+  confirmText="Confirm",
+  cancelText="Cancel",
+  onSubmit,
+  onDismiss,
+  ...modalProps
+}) => (
   <Modal width={480} {...modalProps} onBlur={onDismiss} onEscape={onDismiss}>
     <div className={styles.dialogConfirm}>
       <AppBar>
-        <AppBarTitle>{title || 'Confirm'}</AppBarTitle>
+        <AppBarTitle>{title}</AppBarTitle>
       </AppBar>
       <div className={styles.dialogConfirmContent}>
         {prompt}
@@ -88,13 +102,13 @@ export const ConfirmDialog: React.FunctionComponent<ConfirmDialogProps> = ({titl
           <AppBarSection />
           <AppBarSection>
             <ButtonGroup>
-              <Button variant="underline" onClick={onDismiss}>{cancelText || 'Cancel'}</Button>
+              <Button variant="underline" onClick={onDismiss}>{cancelText}</Button>
               <Button
                 variant="filled"
                 type="primary"
                 onClick={() => onSubmit()}
               >
-                {confirmText || 'Confirm'}
+                {confirmText}
               </Button>
             </ButtonGroup>
           </AppBarSection>
@@ -121,7 +135,18 @@ export type PromptDialogProps = DialogBaseProps & {
   cancelText?: React.ReactNode,
 };
 
-export const PromptDialog: React.FunctionComponent<PromptDialogProps> = ({title, prompt, confirmText, cancelText, onSubmit, onDismiss, placeholder, leftIcon, rightIcon, ...modalProps}) => {
+export const PromptDialog: React.FunctionComponent<PromptDialogProps> = ({
+  title='Prompt',
+  prompt,
+  confirmText='Submit',
+  cancelText='Cancel',
+  onSubmit,
+  onDismiss,
+  placeholder,
+  leftIcon,
+  rightIcon,
+  ...modalProps
+}) => {
   const [ text, setText ] = useState('');
 
   // When a prompt is shown, auto focus its text box.
@@ -136,7 +161,7 @@ export const PromptDialog: React.FunctionComponent<PromptDialogProps> = ({title,
     <Modal width={480} {...modalProps} onBlur={onDismiss} onEscape={onDismiss}>
       <div className={styles.dialogPrompt}>
         <AppBar>
-          <AppBarTitle>{title || 'Prompt'}</AppBarTitle>
+          <AppBarTitle>{title}</AppBarTitle>
         </AppBar>
         <div className={styles.dialogPromptContent}>
           {prompt ? (
@@ -165,13 +190,13 @@ export const PromptDialog: React.FunctionComponent<PromptDialogProps> = ({title,
             <AppBarSection></AppBarSection>
             <AppBarSection>
               <ButtonGroup>
-                <Button variant="underline" onClick={onDismiss}>{cancelText || 'Cancel'}</Button>
+                <Button variant="underline" onClick={onDismiss}>{cancelText}</Button>
                 <Button
                   variant="filled"
                   type="primary"
                   onClick={() => onSubmit(text)}
                 >
-                  {confirmText || 'Submit'}
+                  {confirmText}
                 </Button>
               </ButtonGroup>
             </AppBarSection>

--- a/src/dialog/index.tsx
+++ b/src/dialog/index.tsx
@@ -71,9 +71,10 @@ export type ConfirmDialogProps = DialogBaseProps & {
 
   title?: React.ReactNode,
   confirmText?: React.ReactNode,
+  cancelText?: React.ReactNode,
 };
 
-export const ConfirmDialog: React.FunctionComponent<ConfirmDialogProps> = ({title, prompt, confirmText, onSubmit, onDismiss, ...modalProps}) => (
+export const ConfirmDialog: React.FunctionComponent<ConfirmDialogProps> = ({title, prompt, confirmText, cancelText, onSubmit, onDismiss, ...modalProps}) => (
   <Modal width={480} {...modalProps} onBlur={onDismiss} onEscape={onDismiss}>
     <div className={styles.dialogConfirm}>
       <AppBar>
@@ -87,7 +88,7 @@ export const ConfirmDialog: React.FunctionComponent<ConfirmDialogProps> = ({titl
           <AppBarSection />
           <AppBarSection>
             <ButtonGroup>
-              <Button variant="underline" onClick={onDismiss}>Cancel</Button>
+              <Button variant="underline" onClick={onDismiss}>{cancelText || 'Cancel'}</Button>
               <Button
                 variant="filled"
                 type="primary"
@@ -117,9 +118,10 @@ export type PromptDialogProps = DialogBaseProps & {
   leftIcon?: React.ReactNode,
   rightIcon?: React.ReactNode,
   confirmText?: React.ReactNode,
+  cancelText?: React.ReactNode,
 };
 
-export const PromptDialog: React.FunctionComponent<PromptDialogProps> = ({title, prompt, confirmText, onSubmit, onDismiss, placeholder, leftIcon, rightIcon, ...modalProps}) => {
+export const PromptDialog: React.FunctionComponent<PromptDialogProps> = ({title, prompt, confirmText, cancelText, onSubmit, onDismiss, placeholder, leftIcon, rightIcon, ...modalProps}) => {
   const [ text, setText ] = useState('');
 
   // When a prompt is shown, auto focus its text box.
@@ -163,7 +165,7 @@ export const PromptDialog: React.FunctionComponent<PromptDialogProps> = ({title,
             <AppBarSection></AppBarSection>
             <AppBarSection>
               <ButtonGroup>
-                <Button variant="underline" onClick={onDismiss}>Cancel</Button>
+                <Button variant="underline" onClick={onDismiss}>{cancelText || 'Cancel'}</Button>
                 <Button
                   variant="filled"
                   type="primary"

--- a/src/dialog/index.tsx
+++ b/src/dialog/index.tsx
@@ -23,7 +23,7 @@ type DialogBaseProps = {
 // ----------------------------------------------------------------------------
 // ALERT DIALOG
 // ----------------------------------------------------------------------------
-type AlertDialogProps = DialogBaseProps & {
+export type AlertDialogProps = DialogBaseProps & {
   prompt: React.ReactNode,
   onSubmit: () => void,
 
@@ -64,7 +64,7 @@ AlertDialog.displayName = 'AlertDialog';
 // ----------------------------------------------------------------------------
 // CONFIRM DIALOG
 // ----------------------------------------------------------------------------
-type ConfirmDialogProps = DialogBaseProps & {
+export type ConfirmDialogProps = DialogBaseProps & {
   prompt: React.ReactNode,
   onSubmit: () => void,
   onDismiss: () => void,
@@ -107,7 +107,7 @@ ConfirmDialog.displayName = 'ConfirmDialog';
 // ----------------------------------------------------------------------------
 // PROMPT DIALOG
 // ----------------------------------------------------------------------------
-type PromptDialogProps = DialogBaseProps & {
+export type PromptDialogProps = DialogBaseProps & {
   prompt: React.ReactNode,
   onSubmit: (text: string) => void,
   onDismiss: () => void,

--- a/src/dialog/story.js
+++ b/src/dialog/story.js
@@ -1,0 +1,116 @@
+import React, { Fragment, Component } from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import { ConfirmDialog, AlertDialog, PromptDialog } from '.';
+import { Button, Icons } from '..';
+
+class DialogTriggerer extends Component {
+  state = {
+    view: 'HIDDEN', /* 'TRANSITION_TO_VISIBLE', 'VISIBLE', 'TRANSITION_TO_HIDDEN' */
+  }
+
+  show = () => {
+    this.setState({view: 'TRANSITION_TO_VISIBLE'}, () => {
+      this.setState({view: 'VISIBLE'});
+    });
+  }
+
+  hide = () => {
+    this.setState({view: 'TRANSITION_TO_HIDDEN'}, () => {
+      setTimeout(() => {
+        this.setState({view: 'HIDDEN'});
+      }, 500);
+    });
+  }
+
+  render() {
+    return (
+      <Fragment>
+        <Button onClick={this.show}>Open dialog</Button>
+        {['TRANSITION_TO_VISIBLE', 'VISIBLE', 'TRANSITION_TO_HIDDEN'].includes(this.state.view) ?
+            this.props.children(this.state.view === 'VISIBLE', this.hide) : null}
+      </Fragment>
+    );
+  }
+}
+
+storiesOf('Dialog / Alert', module)
+  .add('Alert Dialog', () => (
+    <DialogTriggerer children={(visibility, hide) => (
+      <AlertDialog
+        prompt="You have clicked a button. Congratulations!"
+        onSubmit={hide}
+        onDismiss={hide}
+        visible={visibility}
+      />
+    )} />
+  ))
+  .add('Alert Dialog (with custom title and confirm text)', () => (
+    <DialogTriggerer children={(visibility, hide) => (
+      <AlertDialog
+        title="Fancy Title"
+        prompt="You have clicked a button. Congratulations!"
+        confirmText="Yay me!"
+        onSubmit={hide}
+        onDismiss={hide}
+        visible={visibility}
+      />
+    )} />
+  ))
+
+storiesOf('Dialog / Confirm', module)
+  .add('Confirm Dialog', () => (
+    <DialogTriggerer children={(visibility, hide) => (
+      <ConfirmDialog
+        prompt="Do you like web development?"
+        onSubmit={hide}
+        onDismiss={hide}
+        visible={visibility}
+      />
+    )} />
+  ))
+  .add('Confirm Dialog (with custom title and confirm text)', () => (
+    <DialogTriggerer children={(visibility, hide) => (
+      <ConfirmDialog
+        title="Save changes"
+        prompt="Would you like to leave without saving?"
+        confirmText="Leave"
+        onSubmit={hide}
+        onDismiss={hide}
+        visible={visibility}
+      />
+    )} />
+  ))
+
+storiesOf('Dialog / Prompt', module)
+  .add('Prompt Dialog', () => (
+    <DialogTriggerer children={(visibility, hide) => (
+      <PromptDialog
+        prompt="What is your favorite ice cream?"
+        onSubmit={result => {
+          console.log('Favorite ice cream:', result);
+          hide();
+        }}
+        onDismiss={hide}
+        visible={visibility}
+      />
+    )} />
+  ))
+  .add('Confirm Dialog (with custom title, confirm text, placeholder, and left icon)', () => (
+    <DialogTriggerer children={(visibility, hide) => (
+      <PromptDialog
+        title="Favorite ice cream"
+        prompt="What is your favorite ice cream?"
+        confirmText="Give me some!"
+        placeholder="ex: Chocolate"
+        leftIcon={<Icons.Soup />}
+        onSubmit={result => {
+          console.log('Favorite ice cream:', result);
+          hide();
+        }}
+        onDismiss={hide}
+        visible={visibility}
+      />
+    )} />
+  ))

--- a/src/dialog/story.js
+++ b/src/dialog/story.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import { ConfirmDialog, AlertDialog, PromptDialog } from '.';
-import { Button, Icons } from '..';
+import { Button, ButtonGroup, Icons } from '..';
 
 class DialogTriggerer extends Component {
   state = {

--- a/src/dialog/styles.module.scss
+++ b/src/dialog/styles.module.scss
@@ -1,0 +1,14 @@
+@import "../../variables/colors.scss";
+@import "../../variables/fonts.scss";
+
+.dialogConfirm {
+  display: flex;
+  flex-direction: column;
+}
+.dialogConfirmContent { padding: 32px; }
+
+.dialogPromptContent { padding: 32px; }
+.dialogPromptLabel {
+  padding-bottom: 16px;
+  font-size: $fontSizeBase;
+}

--- a/src/dialogger/index.tsx
+++ b/src/dialogger/index.tsx
@@ -1,0 +1,189 @@
+import React, { useEffect, useReducer } from 'react';
+import ReactDOM from 'react-dom';
+import { v4 as uuidv4 } from 'uuid';
+
+import {
+  AlertDialog,
+  ConfirmDialog,
+  PromptDialog,
+} from '..';
+import { PromptDialogProps, ConfirmDialogProps, AlertDialogProps } from '../dialog';
+
+type AlertDialogOptions = Omit<AlertDialogProps, 'visible' | 'onSubmit'>;
+type ConfirmDialogOptions = Omit<ConfirmDialogProps, 'visible' | 'onSubmit' | 'onDismiss'>;
+type PromptDialogOptions = Omit<PromptDialogProps, 'visible' | 'onSubmit' | 'onDismiss'>;
+
+type DialogOptions =
+  | {
+    type: 'ALERT',
+    options: AlertDialogOptions,
+    resolve: () => void,
+  }
+  | {
+    type: 'CONFIRM',
+    options: ConfirmDialogOptions,
+    resolve: (confirmed: boolean) => void,
+  }
+  | {
+    type: 'PROMPT',
+    options: PromptDialogOptions,
+    resolve: (text: string | null) => void,
+  };
+
+type OpenDialogState = DialogOptions & {visible: boolean};
+type DialoggerState = OpenDialogState | null;
+
+enum DialoggerActionTypes {
+  TRANSITION_TO_SHOW_DIALOG = 'TRANSITION_TO_SHOW_DIALOG',
+  DIALOG_SHOW = 'DIALOG_SHOW',
+  TRANSITION_TO_HIDE_DIALOG = 'TRANSITION_TO_HIDE_DIALOG',
+  DIALOG_HIDE = 'DIALOG_HIDE',
+}
+
+type DialoggerAction =
+  | {
+      type: DialoggerActionTypes.TRANSITION_TO_SHOW_DIALOG;
+      options: DialogOptions;
+    }
+  | { type: DialoggerActionTypes.DIALOG_SHOW }
+  | { type: DialoggerActionTypes.TRANSITION_TO_HIDE_DIALOG }
+  | { type: DialoggerActionTypes.DIALOG_HIDE };
+
+function dialoggerReducer(state: DialoggerState, action: DialoggerAction) {
+  switch (action.type) {
+    case DialoggerActionTypes.TRANSITION_TO_SHOW_DIALOG:
+      return { ...action.options, visible: false };
+    case DialoggerActionTypes.DIALOG_SHOW:
+      return { ...state, visible: true };
+    case DialoggerActionTypes.TRANSITION_TO_HIDE_DIALOG:
+      return { ...state, visible: false };
+    case DialoggerActionTypes.DIALOG_HIDE:
+      return null;
+    default:
+      return state;
+  }
+}
+
+let dispatch: any = null;
+
+type DialoggerType = React.FunctionComponent & {
+  alert: (options: AlertDialogOptions) => Promise<void>,
+  confirm: (options: ConfirmDialogOptions) => Promise<boolean>,
+  prompt: (options: PromptDialogOptions) => Promise<string | null>,
+};
+
+const Dialogger: DialoggerType = () => {
+  const [ state, localDispatch ] = useReducer(dialoggerReducer, null);
+
+  // Store a reference of dispatch outside the component. This is so that
+  // the alert / confirm / prompt static methods can use this reference to dispatch actions outside
+  // of the component's lexical context to open dialogs.
+  useEffect(() => {
+    if (dispatch !== null) {
+      throw new Error(`More than one <Dialogger /> is being rendered - this isn't allowed. Please render a single dialogger.`);
+    }
+    dispatch = localDispatch;
+    return () => {
+      dispatch = null;
+    }
+  });
+
+  const hideDialog = function() {
+    dispatch({ type: DialoggerActionTypes.TRANSITION_TO_HIDE_DIALOG });
+    setTimeout(() => {
+      dispatch({ type: DialoggerActionTypes.DIALOG_HIDE });
+    }, 500);
+  };
+
+  if (state === null) {
+    return null;
+  }
+
+  switch (state.type) {
+  case 'ALERT':
+    return (
+      <AlertDialog
+        {...state.options}
+        visible={state.visible}
+        onSubmit={() => {
+          hideDialog();
+          state.resolve();
+        }}
+      />
+    );
+  case 'CONFIRM':
+    return (
+      <ConfirmDialog
+        {...state.options}
+        visible={state.visible}
+        onSubmit={() => {
+          hideDialog();
+          state.resolve(true);
+        }}
+        onDismiss={() => {
+          hideDialog();
+          state.resolve(false);
+        }}
+      />
+    );
+  case 'PROMPT':
+    return (
+      <PromptDialog
+        {...state.options}
+
+        visible={state.visible}
+        onSubmit={text => {
+          hideDialog();
+          state.resolve(text);
+        }}
+        onDismiss={() => {
+          hideDialog();
+          state.resolve(null);
+        }}
+      />
+    );
+  default:
+    return null;
+  }
+}
+Dialogger.displayName = 'Dialogger';
+export default Dialogger;
+
+const DISPATCH_UNDEFINED_ERROR = 'Please render a <Dialogger /> component at the root of the application to use the Dialogger.';
+
+Dialogger.alert = async function(options) {
+  return new Promise((resolve) => {
+    if (!dispatch) {
+      throw new Error(DISPATCH_UNDEFINED_ERROR);
+    }
+    dispatch({
+      type: DialoggerActionTypes.TRANSITION_TO_SHOW_DIALOG,
+      options: { type: 'ALERT', options, resolve },
+    });
+    dispatch({ type: DialoggerActionTypes.DIALOG_SHOW });
+  });
+};
+Dialogger.confirm = async function(options) {
+  return new Promise((resolve) => {
+    if (!dispatch) {
+      throw new Error(DISPATCH_UNDEFINED_ERROR);
+    }
+    dispatch({
+      type: DialoggerActionTypes.TRANSITION_TO_SHOW_DIALOG,
+      options: { type: 'CONFIRM', options, resolve },
+    });
+    dispatch({ type: DialoggerActionTypes.DIALOG_SHOW });
+  });
+};
+Dialogger.prompt = async function(options) {
+  return new Promise((resolve) => {
+    if (!dispatch) {
+      throw new Error(DISPATCH_UNDEFINED_ERROR);
+    }
+    dispatch({
+      type: DialoggerActionTypes.TRANSITION_TO_SHOW_DIALOG,
+      options: { type: 'PROMPT', options, resolve },
+    });
+    dispatch({ type: DialoggerActionTypes.DIALOG_SHOW });
+  });
+};

--- a/src/dialogger/story.tsx
+++ b/src/dialogger/story.tsx
@@ -1,0 +1,49 @@
+import React, { Fragment, Component } from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { Dialogger, Button, ButtonGroup } from '..';
+
+storiesOf('Dialogger', module)
+  .add('Dialogger Test', () => (
+    <Fragment>
+      {/* The Dialogger should be rendered at the root of the app, and never rendered conditionally. */}
+      {/* If the Dialogger is not rendered and you call any of the static methods on the Dialogger, an error will be raised! */}
+      <Dialogger />
+
+      <p>
+        Click any of the below buttons to open a dialog.
+      </p>
+      <ButtonGroup>
+        <Button onClick={() => {
+          Dialogger.alert({ prompt: "Foo" }).then(() => {
+            console.log('Alert closed!');
+          });
+        }}>
+          Open Alert
+        </Button>
+        <Button onClick={() => {
+          Dialogger.confirm({
+            title: "Save changes",
+            prompt: "Would you like to leave without saving?",
+            confirmText: "Leave",
+          }).then(confirmed => {
+            console.log('Confirmed:', confirmed);
+          });
+        }}>
+          Open Confirm
+        </Button>
+        <Button onClick={() => {
+          Dialogger.prompt({
+            title: "Favorite Ice Cream",
+            prompt: "What is your favorite ice cream?",
+            confirmText: "Give me some!",
+            placeholder: "ex: Chocolate",
+          }).then(result => {
+            console.log('Typed text:', result);
+          });
+        }}>
+          Open Prompt
+        </Button>
+      </ButtonGroup>
+    </Fragment>
+  ))

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export { default as PhoneInputBox } from './phone-input-box';
 export { default as RadioButton, RadioButtonContext } from './radio-button';
 export { default as Switch } from './switch';
 export { default as Toast, ToastContext } from './toast';
+export { default as Toaster } from './toaster';
 export { default as Skeleton } from './skeleton';
 export { default as TagInput } from './tag-input';
 export { default as DayOfWeekPicker } from './day-of-week-picker';

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ export { default as RadioButton, RadioButtonContext } from './radio-button';
 export { default as Switch } from './switch';
 export { default as Toast, ToastContext } from './toast';
 export { default as Toaster } from './toaster';
+export { AlertDialog, ConfirmDialog, PromptDialog } from './dialog';
+export { default as Dialogger } from './dialogger';
 export { default as Skeleton } from './skeleton';
 export { default as TagInput } from './tag-input';
 export { default as DayOfWeekPicker } from './day-of-week-picker';
@@ -31,6 +33,7 @@ export {
   default as SpacePicker,
   SpacePickerDropdown,
   SpacePickerSelectControlTypes,
+  SpacePickerContext,
 } from './space-picker';
 
 export {

--- a/src/toast/story.js
+++ b/src/toast/story.js
@@ -5,8 +5,6 @@ import { action } from '@storybook/addon-actions';
 import './styles.module.scss';
 import Toast, { ToastContext } from './index';
 
-import Icons from '../icons';
-
 storiesOf('Toast', module)
   .add('Default Toast', () => (
     <Toast visible onDismiss={action('onDismiss')}>

--- a/src/toaster/README.md
+++ b/src/toaster/README.md
@@ -1,0 +1,6 @@
+# Toaster
+
+A mechanism for imperatively showing toasts.
+
+## Example code
+See the story code in the same directory as this file.

--- a/src/toaster/index.tsx
+++ b/src/toaster/index.tsx
@@ -1,0 +1,167 @@
+import React, { useEffect, useReducer } from 'react';
+import ReactDOM from 'react-dom';
+import { v4 as uuidv4 } from 'uuid';
+
+import { Toast } from '..';
+
+type ToastId = string;
+type ToastOptions = {
+  text: React.ReactNode,
+  id?: ToastId,
+  type?: 'default' | 'error',
+  timeout?: number | null,
+};
+type ToasterState = Array<ToastOptions & {visible: boolean}>;
+
+// Toasts go through a few lifecycle states:
+enum ToasterActionTypes {
+  // - "TRANSITION_TO_SHOW_TOAST" - render the toast on screen, but invisible
+  TRANSITION_TO_SHOW_TOAST = 'TRANSITION_TO_SHOW_TOAST',
+
+  // - "TOAST_SHOW" - fade the toast in; on completion of this step, it's officially "shown"
+  TOAST_SHOW = 'TOAST_SHOW',
+
+  // - "TRANSITION_TO_HIDE_TOAST" - fade the toast out,
+  TRANSITION_TO_HIDE_TOAST = 'TRANSITION_TO_HIDE_TOAST',
+
+  // - "TOAST_SHOW" - remove the toast from the dom; on completion of this step it's officially "hidden"
+  TOAST_HIDE = 'TOAST_HIDE',
+}
+
+type ToasterAction =
+  | {
+      type: ToasterActionTypes.TRANSITION_TO_SHOW_TOAST;
+      options: ToastOptions;
+    }
+  | { type: ToasterActionTypes.TOAST_SHOW; id: ToastId }
+  | { type: ToasterActionTypes.TRANSITION_TO_HIDE_TOAST; id: ToastId }
+  | { type: ToasterActionTypes.TOAST_HIDE; id: ToastId };
+
+function toasterReducer(state: ToasterState, action: ToasterAction) {
+  switch (action.type) {
+    case ToasterActionTypes.TRANSITION_TO_SHOW_TOAST:
+      return [...state, { ...action.options, visible: false }];
+    case ToasterActionTypes.TOAST_SHOW:
+      return state.map((toast) => {
+        if (toast.id === action.id) {
+          return { ...toast, visible: true };
+        } else {
+          return toast;
+        }
+      });
+    case ToasterActionTypes.TRANSITION_TO_HIDE_TOAST:
+      return state.map((toast) => {
+        if (toast.id === action.id) {
+          return { ...toast, visible: false };
+        } else {
+          return toast;
+        }
+      });
+    case ToasterActionTypes.TOAST_HIDE:
+      return state.filter((x) => x.id !== action.id);
+    default:
+      return state;
+  }
+}
+
+let dispatch: React.Dispatch<ToasterAction> | null = null;
+
+type ToasterType = React.FunctionComponent<{width: number, top: React.ReactText}> & {
+  showToast: (options: ToastOptions) => ToastId,
+  hideToast: (id: ToastId) => void,
+};
+const Toaster: ToasterType = ({width=360, top=40}) => {
+  const [ state, localDispatch ] = useReducer(toasterReducer, []);
+
+  // Store a reference of dispatch outside the component. This is so that
+  // showToast / hideToast can use this reference to dispatch actions outside of the
+  // component's lexical context.
+  useEffect(() => {
+    if (dispatch !== null) {
+      throw new Error(`More than one <Toaster /> is being rendered - this isn't allowed. Please render a single toaster.`);
+    }
+
+    dispatch = localDispatch;
+    return () => {
+      dispatch = null;
+    }
+  }, []);
+
+  return ReactDOM.createPortal(
+    <div
+      style={{
+        position: 'fixed',
+        top,
+        left: '50%',
+
+        marginLeft: -1 * (width / 2),
+        width,
+      }}
+    >
+      {state.map((toast, index) => {
+        const type = toast.type || 'default';
+        return (
+          <div key={index} style={{
+            transition: 'all 100ms ease-in-out',
+            height: toast.visible ? 50 : 0,
+          }}>
+            <Toast
+              key={toast.id}
+              type={type}
+              visible={toast.visible}
+              onDismiss={() => Toaster.hideToast(toast.id)}
+            >
+              {toast.text}
+            </Toast>
+          </div>
+        );
+      })}
+    </div>,
+    document.body,
+  );
+}
+Toaster.displayName = 'Toaster';
+
+Toaster.showToast = function showToast(options: ToastOptions): ToastId {
+  if (!dispatch) {
+    throw new Error('Before calling Toaster.showToast, please render a <Toaster /> component.');
+  }
+
+  options.id = options.id || uuidv4();
+  if (typeof options.timeout === 'undefined') {
+    options.timeout = 3000;
+  }
+
+  // Add the toast to the screen, but keep it invisible
+  dispatch({
+    type: ToasterActionTypes.TRANSITION_TO_SHOW_TOAST,
+    options,
+  });
+
+  // Fade in the toast so it's visible
+  dispatch({
+    type: ToasterActionTypes.TOAST_SHOW,
+    id: options.id,
+  });
+
+  if (options.timeout !== null) {
+    setTimeout(() => Toaster.hideToast(options.id), options.timeout);
+  }
+
+  return options.id;
+};
+
+Toaster.hideToast = async function hideToast(id: ToastId) {
+  return new Promise((resolve) => {
+    // Fade out the toast but keep it in the dom
+    dispatch({ type: ToasterActionTypes.TRANSITION_TO_HIDE_TOAST, id });
+
+    // After fading it out is complete, then remove it.
+    setTimeout(() => {
+      dispatch({ type: ToasterActionTypes.TOAST_HIDE, id });
+      resolve();
+    }, 500);
+  });
+};
+
+export default Toaster;

--- a/src/toaster/index.tsx
+++ b/src/toaster/index.tsx
@@ -7,9 +7,9 @@ import { Toast } from '..';
 type ToastId = string;
 type ToastOptions = {
   text: React.ReactNode,
-  id?: ToastId,
-  type?: 'default' | 'error',
-  timeout?: number | null,
+  id: ToastId,
+  type: 'default' | 'error',
+  timeout: number | null,
 };
 type ToasterState = Array<ToastOptions & {visible: boolean}>;
 
@@ -67,7 +67,7 @@ function toasterReducer(state: ToasterState, action: ToasterAction) {
 let dispatch: React.Dispatch<ToasterAction> | null = null;
 
 type ToasterType = React.FunctionComponent<{width: number, top: React.ReactText}> & {
-  showToast: (options: ToastOptions) => ToastId,
+  showToast: (options: Partial<ToastOptions>) => ToastId,
   hideToast: (id: ToastId) => void,
 };
 const Toaster: ToasterType = ({width=360, top=40}) => {
@@ -122,33 +122,35 @@ const Toaster: ToasterType = ({width=360, top=40}) => {
 }
 Toaster.displayName = 'Toaster';
 
-Toaster.showToast = function showToast(options: ToastOptions): ToastId {
+Toaster.showToast = function showToast(options: Partial<ToastOptions>): ToastId {
   if (!dispatch) {
     throw new Error('Before calling Toaster.showToast, please render a <Toaster /> component.');
   }
 
-  options.id = options.id || uuidv4();
-  if (typeof options.timeout === 'undefined') {
-    options.timeout = 3000;
-  }
+  const optionsWithDefaults: ToastOptions = {
+    text: options.text || '',
+    id: options.id || uuidv4(),
+    type: options.type || 'default',
+    timeout: typeof options.timeout !== 'undefined' ? options.timeout : 3000,
+  };
 
   // Add the toast to the screen, but keep it invisible
   dispatch({
     type: ToasterActionTypes.TRANSITION_TO_SHOW_TOAST,
-    options,
+    options: optionsWithDefaults,
   });
 
   // Fade in the toast so it's visible
   dispatch({
     type: ToasterActionTypes.TOAST_SHOW,
-    id: options.id,
+    id: optionsWithDefaults.id,
   });
 
-  if (options.timeout !== null) {
-    setTimeout(() => Toaster.hideToast(options.id), options.timeout);
+  if (optionsWithDefaults.timeout !== null) {
+    setTimeout(() => Toaster.hideToast(optionsWithDefaults.id), optionsWithDefaults.timeout);
   }
 
-  return options.id;
+  return optionsWithDefaults.id;
 };
 
 Toaster.hideToast = async function hideToast(id: ToastId) {

--- a/src/toaster/story.js
+++ b/src/toaster/story.js
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import Toaster from './index';
+
+import { Button, ButtonGroup, Icons } from '..';
+
+storiesOf('Toaster', module)
+  .add('Toaster Demo', () => (
+    <div>
+      {/* The toaster should be rendered at the root of the app, and never rendered conditionally. */}
+      {/* If the Toaster is not rendered and you call `Toaster.showToast`, an error will be raised! */}
+      <Toaster />
+
+      <p>
+        Click either of the below buttons to render a toast on screen.
+      </p>
+      <p>
+        Clicking the buttons multiple times will show a stacked list of toasts.
+      </p>
+      <ButtonGroup>
+        <Button onClick={() => Toaster.showToast({text: 'Foo'})}>Show a toast</Button>
+        <Button onClick={() => Toaster.showToast({text: 'Error!', type: 'error'})}>
+          Show an error toast
+        </Button>
+      </ButtonGroup>
+    </div>
+  ))


### PR DESCRIPTION
### Dialogs
Implements all the dialog implementations in the dashboard within Density UI. Effectively, these are opinionated modals that make rendering alerts, confirm boxes, and prompts easier:

<img width="557" alt="Screen Shot 2020-07-01 at 9 24 58 AM" src="https://user-images.githubusercontent.com/1704236/86249058-c09bdb80-bb7c-11ea-90a9-18e5b90313ba.png">


### Toaster and Dialogger
Brings over the concepts of the toaster and dialogger from the dashboard. These primitives allow for dialogs and toasts to be created imperatively, which often fits better with the way they are used within interfaces. Both of these are "singleton components" - ie, they are rendered once at the root of the app. They each have static methods on them for creating toasts and dialogs - these being `Toaster.showToast` and `Dialogger.alert` / `Dialogger.confirm` / `Dialogger.prompt`. See the stories in the diff for a usage example of each.

<img src="http://g.recordit.co/pJZtsHmGJM.gif" />