### PR TITLE
Add ability to make dialogger prompt that requires input

### DIFF
--- a/src/dialog/index.tsx
+++ b/src/dialog/index.tsx
@@ -134,6 +134,7 @@ export type PromptDialogProps = DialogBaseProps & {
   confirmText?: React.ReactNode,
   cancelText?: React.ReactNode,
   initialText?: string,
+  emptyValueIsInvalid?: boolean,
 };
 
 export const PromptDialog: React.FunctionComponent<PromptDialogProps> = ({
@@ -147,6 +148,7 @@ export const PromptDialog: React.FunctionComponent<PromptDialogProps> = ({
   leftIcon,
   rightIcon,
   initialText,
+  emptyValueIsInvalid,
   ...modalProps
 }) => {
   const [ text, setText ] = useState(initialText || '');
@@ -158,6 +160,8 @@ export const PromptDialog: React.FunctionComponent<PromptDialogProps> = ({
       (textBoxRef as any).current.focus();
     }
   }, [modalProps.visible, textBoxRef]);
+
+  const disabled = emptyValueIsInvalid && text.length === 0;
 
   return (
     <Modal width={480} {...modalProps} onBlur={onDismiss} onEscape={onDismiss}>
@@ -173,14 +177,14 @@ export const PromptDialog: React.FunctionComponent<PromptDialogProps> = ({
           ) : null}
           <InputBox
             type="text"
-            value={text || ''}
+            value={text}
             onChange={e => setText(e.target.value)}
             placeholder={placeholder}
             leftIcon={leftIcon}
             rightIcon={rightIcon}
             width="100%"
             onKeyDown={e => {
-              if (e.key === 'Enter') {
+              if (!disabled && e.key === 'Enter') {
                 onSubmit(text);
               }
             }}
@@ -196,6 +200,7 @@ export const PromptDialog: React.FunctionComponent<PromptDialogProps> = ({
                 <Button
                   variant="filled"
                   type="primary"
+                  disabled={disabled}
                   onClick={() => onSubmit(text)}
                 >
                   {confirmText}

--- a/src/dialogger/story.tsx
+++ b/src/dialogger/story.tsx
@@ -44,6 +44,19 @@ storiesOf('Dialogger', module)
         }}>
           Open Prompt
         </Button>
+        <Button onClick={() => {
+          Dialogger.prompt({
+            title: "Favorite Ice Cream",
+            prompt: "What is your favorite ice cream?",
+            confirmText: "Give me some!",
+            placeholder: "ex: Chocolate",
+            emptyValueIsInvalid: true,
+          }).then(result => {
+            console.log('Typed text:', result);
+          });
+        }}>
+          Open Prompt (requires text)
+        </Button>
       </ButtonGroup>
     </Fragment>
   ))


### PR DESCRIPTION
This was a feature request from #406. Adds a flag so that when enabled, a prompt can only be submitted when text is entered into the text box.