### PR TITLE
Suggested typing changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "21.8.2",
+  "version": "21.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/environment-switcher/index.tsx
+++ b/src/environment-switcher/index.tsx
@@ -96,40 +96,47 @@ type EnvironmentSwitcherState<C extends EnvironmentConfigurationBase> = {
   configuration: C /* version of the configuration used by the app */;
 };
 
+type LocalEnvironmentConfigurationBase<G extends EnvironmentConfigurationBase> = G & {
+  [key: string]: any,
+}
+
+type CustomEnvironmentConfigurationBase<G extends EnvironmentConfigurationBase> = G & {
+  [key: string]: any,
+}
 
 type EnvironmentSwitcherProps<
-  L extends object,
-  C extends object,
-  G extends object,
+  G extends EnvironmentConfigurationBase,
+  L extends LocalEnvironmentConfigurationBase<G>,
+  C extends CustomEnvironmentConfigurationBase<G>,
 > = {
   // Settings shown in "More options" panel
   globalSettings: G;
   globalControls?: (
-    config: { type: Environment } & G & EnvironmentConfigurationBase,
-    setConfig: (config: { type: Environment } & G & EnvironmentConfigurationBase) => void,
+    config: { type: Environment } & G,
+    setConfig: (config: { type: Environment } & G) => void,
   ) => React.ReactNode;
 
   // Settings shown when "local" environment is selected
   localEnvironmentControls: (
-    config: { type: Environment.LOCAL } & L & G & EnvironmentConfigurationBase,
-    setConfig: (config: L & G & EnvironmentConfigurationBase) => void,
+    config: { type: Environment.LOCAL } & L,
+    setConfig: (config: { type: Environment.LOCAL } & L) => void,
   ) => React.ReactNode;
   localEnvironmentDefaultValue: L,
 
   // Settings shown when "custom" environment is selected
   customEnvironmentControls: (
-    config: { type: Environment.CUSTOM } & C & G & EnvironmentConfigurationBase,
-    setConfig: (config: C & G & EnvironmentConfigurationBase) => void,
+    config: {type: Environment.CUSTOM } & C,
+    setConfig: (config: { type: Environment.CUSTOM } & C) => void,
   ) => React.ReactNode;
   customEnvironmentDefaultValue: C,
 };
 
 // See https://stackoverflow.com/a/63279565/4115328 for more info on this syntax
 type EnvironmentSwitcherComponentType = <
-  L extends object, // Local configuration shape
-  C extends object, // Custom configuration shape
   G extends EnvironmentConfigurationBase, // Global configuration shape
->(p: EnvironmentSwitcherProps<L, C, G>) => React.ReactElement;
+  L extends LocalEnvironmentConfigurationBase<G>, // Local configuration shape
+  C extends CustomEnvironmentConfigurationBase<G>, // Custom configuration shape
+>(p: EnvironmentSwitcherProps<G, L, C>) => React.ReactElement;
 
 export const EnvironmentSwitcher: EnvironmentSwitcherComponentType = ({
   localEnvironmentControls,

--- a/src/environment-switcher/story.tsx
+++ b/src/environment-switcher/story.tsx
@@ -17,6 +17,7 @@ import colorVariables from "../../variables/colors.json";
 const DEFAULT_LOCAL_CORE_API_PORT = 8000;
 
 const DEFAULT_SETTING_VALUES = {
+  showEnvironmentSwitcher: false,
   featureFlag: false,
 };
 


### PR DESCRIPTION
Hey @1egoman 
Here are a couple suggested tweaks.

I re-ordered the generics so that G (global) comes first, that way L (local) and C (custom) can extend G, without having to repeatedly use `& G` inside the implementation. I also made some named types for {Local,Custom}EnvironmentConfigurationBase so that they can be extended in the generics. I think it cleans it up a bit and makes it more readable, and still passes through the correct types.

Let me know what you think, these are just suggestions.