### PR TITLE
Fix space picker bug with multi-select in a filtered view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "21.9.1-cat",
+  "version": "21.9.1",
   "description": "A UI framework for density projects",
   "scripts": {
     "build-storybook": "build-storybook",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "21.9.0",
+  "version": "21.9.1-cat",
   "description": "A UI framework for density projects",
   "scripts": {
     "build-storybook": "build-storybook",

--- a/src/space-picker/index.tsx
+++ b/src/space-picker/index.tsx
@@ -99,9 +99,10 @@ export const SpacePicker: React.FunctionComponent<SpacePickerProps> = ({
   // The select control is the control to the left of each space that can be clicked to select it.
   const defaultSelectControl = canSelectMultiple ? SpacePickerSelectControlTypes.CHECKBOX : SpacePickerSelectControlTypes.RADIOBUTTON;
   selectControl = selectControl || defaultSelectControl;
+  let filteredFormattedHierarchy = formattedHierarchy;
 
   if (searchText.length > 0) {
-    formattedHierarchy = spaceHierarchySearcher(formattedHierarchy, searchText);
+    filteredFormattedHierarchy = spaceHierarchySearcher(formattedHierarchy, searchText);
   }
 
   // This function normalizes the difference between when `canSelectMultiple` is set or unset.
@@ -143,7 +144,7 @@ export const SpacePicker: React.FunctionComponent<SpacePickerProps> = ({
       </div> : null}
 
       <div className={styles.scrollContainer} style={{height}}>
-        {formattedHierarchy.map(item => {
+        {filteredFormattedHierarchy.map(item => {
           const spaceDisabled = disabled || !item.space.has_purview || isItemDisabled(item);
           const isChecked = Boolean(selectedSpaceIds.find(id => id === item.space.id));
 

--- a/src/space-picker/story.js
+++ b/src/space-picker/story.js
@@ -950,6 +950,15 @@ storiesOf('SpacePicker/Regular Space Picker', module)
         <Wrapper />
       </div>
     );
+  },
+  {
+    notes: `Test an edge case with filtering:
+
+    1. Select a space (e.g. Ames)
+    2. Filter to a view without the select space (e.g. by typing "Dallas")
+    3. Select another space (e.g. Dallas)
+    4. Undo the search and filter. Make sure that both spaces are still selected.
+    `,
   })
   .add('Space Picker: with all buildings disabled', () => {
     function Wrapper() {


### PR DESCRIPTION
There's a bug with space picker and multiselect where if we:

1. Select the first space from the current space list, then
2. Filter the list to a view without the first space, then
3. Select another space from the filtered list

There will be an error because at step 3, we try to get the `space_id` of selected spaces by mapping them to the filtered space list -- which doesn't include the first space.

Fixed this by creating another new or the filtered view (`filteredFormattedHierarchy`) and keeping the original list intact.

Closes [PRD-489](https://densityio.atlassian.net/browse/PRD-489).