### PR TITLE
PRD-2143: auto-select children setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "22.1.5",
+  "version": "22.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "22.1.5",
+  "version": "22.1.6",
   "description": "A UI framework for density projects",
   "scripts": {
     "build-storybook": "build-storybook",

--- a/src/space-picker/index.tsx
+++ b/src/space-picker/index.tsx
@@ -112,15 +112,21 @@ export const SpacePicker: React.FunctionComponent<SpacePickerProps> = ({
     if (canSelectMultiple) {
       if (isChecked) {
         onChange(formattedHierarchy.filter(h => {
-          return h.space.id === item.space.id ||
-            (autoSelectChildren && h.ancestry.map(a => a.id).includes(item.space.id)) ||
-            selectedSpaceIds.includes(h.space.id);
+          const isSpaceSelected = h.space.id === item.space.id;
+          const isAutoSelectedChild = autoSelectChildren ?
+            h.ancestry.map(a => a.id).includes(item.space.id) : false;
+          const isAlreadySelected = selectedSpaceIds.includes(h.space.id);
+  
+          return isSpaceSelected || isAutoSelectedChild || isAlreadySelected;
         }));
       } else {
         onChange(formattedHierarchy.filter(h => {
-          return h.space.id !== item.space.id &&
-            (!autoSelectChildren || !h.ancestry.map(a => a.id).includes(item.space.id)) &&
-            selectedSpaceIds.includes(h.space.id);
+          const isSpaceSelected = h.space.id === item.space.id;
+          const isAutoSelectedChild = autoSelectChildren ?
+            h.ancestry.map(a => a.id).includes(item.space.id) : false;
+          const isAlreadySelected = selectedSpaceIds.includes(h.space.id);
+
+          return !isSpaceSelected && !isAutoSelectedChild && isAlreadySelected;
         }));
       }
     } else {

--- a/src/space-picker/index.tsx
+++ b/src/space-picker/index.tsx
@@ -32,6 +32,7 @@ type SpacePickerProps = {
   placeholder?: string,
   height?: React.ReactText,
   canSelectMultiple?: boolean,
+  autoSelectChildren?: boolean,
   selectControl?: SpacePickerSelectControlTypes,
   isItemDisabled?: (SpaceHierarchyDisplayItem) => boolean,
   onCloseDropdown?: () => void,
@@ -83,6 +84,7 @@ export const SpacePicker: React.FunctionComponent<SpacePickerProps> = ({
   formattedHierarchy,
 
   canSelectMultiple=false,
+  autoSelectChildren=false,
   isItemDisabled=(s) => false,
   height,
   showSearchBox=true,
@@ -109,16 +111,17 @@ export const SpacePicker: React.FunctionComponent<SpacePickerProps> = ({
   function callOnChange(item, isChecked) {
     if (canSelectMultiple) {
       if (isChecked) {
-        onChange(
-          [...selectedSpaceIds, item.space.id]
-          .map(id => formattedHierarchy.find(h => h.space.id === id))
-        );
+        onChange(formattedHierarchy.filter(h => {
+          return h.space.id === item.space.id ||
+            (autoSelectChildren && h.ancestry.map(a => a.id).includes(item.space.id)) ||
+            selectedSpaceIds.includes(h.space.id);
+        }));
       } else {
-        onChange(
-          selectedSpaceIds
-          .filter(id => id !== item.space.id)
-          .map(id => formattedHierarchy.find(h => h.space.id === id))
-        );
+        onChange(formattedHierarchy.filter(h => {
+          return h.space.id !== item.space.id &&
+            (!autoSelectChildren || !h.ancestry.map(a => a.id).includes(item.space.id)) &&
+            selectedSpaceIds.includes(h.space.id);
+        }));
       }
     } else {
       onChange(item);
@@ -242,6 +245,7 @@ export class SpacePickerDropdown extends Component<SpacePickerDropdownProps, {op
       searchBoxPlaceholder,
       formattedHierarchy,
       canSelectMultiple,
+      autoSelectChildren,
       isItemDisabled,
       onChange,
     } = this.props;
@@ -298,6 +302,7 @@ export class SpacePickerDropdown extends Component<SpacePickerDropdownProps, {op
                 searchBoxPlaceholder={searchBoxPlaceholder}
                 formattedHierarchy={formattedHierarchy}
                 canSelectMultiple={canSelectMultiple}
+                autoSelectChildren={autoSelectChildren}
                 isItemDisabled={isItemDisabled}
                 height={height}
                 onCloseDropdown={() => this.setState({opened: false})}

--- a/src/space-picker/story.js
+++ b/src/space-picker/story.js
@@ -960,6 +960,26 @@ storiesOf('SpacePicker/Regular Space Picker', module)
     4. Undo the search and filter. Make sure that both spaces are still selected.
     `,
   })
+  .add('Space Picker: with multi-select and auto-select children', () => {
+    function Wrapper() {
+      const [ selected, setSelected ] = useState([]);
+      return (
+        <SpacePicker
+          value={selected}
+          onChange={setSelected}
+          formattedHierarchy={formattedHierarchy}
+          canSelectMultiple={true}
+          autoSelectChildren={true}
+        />
+      );
+    }
+
+    return (
+      <div style={{width: 300, height: 300, margin: '100px auto'}}>
+        <Wrapper />
+      </div>
+    );
+  })
   .add('Space Picker: with all buildings disabled', () => {
     function Wrapper() {
       const [ selected, setSelected ] = useState(null);

--- a/src/space-picker/story.js
+++ b/src/space-picker/story.js
@@ -1137,3 +1137,23 @@ storiesOf('SpacePicker/Dropdown Space Picker', module)
       </div>
     );
   })
+  .add('Dropdown Space Picker: with multiple select and auto-select children', () => {
+    function Wrapper() {
+      const [ selected, setSelected ] = useState([]);
+      return (
+        <SpacePickerDropdown
+          value={selected}
+          onChange={setSelected}
+          formattedHierarchy={formattedHierarchy}
+          canSelectMultiple={true}
+          autoSelectChildren={true}
+        />
+      );
+    }
+
+    return (
+      <div style={{width: 300, height: 300, margin: '100px auto'}}>
+        <Wrapper />
+      </div>
+    );
+  })


### PR DESCRIPTION
Adds a prop, `autoSelectChildren`, to the SpacePicker and SpacePickerDropdown. When set to `true`, the picker should ergonomically auto-select or auto-deselect the children of a space.

Requires `canSelectMultiple` to be true for this behavior to apply.