### PR TITLE
BOOTS-164: add new "snap grid" icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "25.0.0",
+  "version": "25.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/ui",
-  "version": "25.0.0",
+  "version": "25.1.0",
   "description": "A UI framework for density projects",
   "scripts": {
     "build-storybook": "build-storybook",

--- a/src/icons/index.tsx
+++ b/src/icons/index.tsx
@@ -147,6 +147,7 @@ import Share2 from './symbols/share-2';
 import SoundOff from './symbols/sound-off';
 import SoundOn from './symbols/sound-on';
 import SpaceAdd from './symbols/space-add';
+import SnapGrid from './symbols/snap-grid';
 import StairsDown from './symbols/stairs-down';
 import StairsUp from './symbols/stairs-up';
 import StarFill from './symbols/star-fill';
@@ -442,6 +443,7 @@ const ICONS = {
   SoundOff: SoundOff,
   SoundOn: SoundOn,
   SpaceAdd: SpaceAdd,
+  SnapGrid: SnapGrid,
 
   EditorSquare: EditorSquare,
   EditorCircle: EditorCircle,

--- a/src/icons/symbols/snap-grid.tsx
+++ b/src/icons/symbols/snap-grid.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+const SnapGrid = ({ width, height, color }) => (
+  <svg width={width || 24} height={height || 24} viewBox="0 0 24 24">
+    <g fill="none" fillRule="evenodd">
+      <rect width={24} height={24} />
+      <path
+        fill={color}
+        fillRule="evenodd"
+        d="M17 5h-2V3h2v2zm-2 4h2V7h-2v2zm2 4h-2v-2h2v2zm-2 4h2v-2h-2v2zm0 4h2v-2h-2v2zM19 17v-2h2v2h-2zm-8-2v2h2v-2h-2zm-4 2v-2h2v2H7zm-4 0v-2h2v2H3z"
+        clipRule="evenodd"
+      />
+    </g>
+  </svg>
+);
+
+export default SnapGrid;


### PR DESCRIPTION
I had Aglae make me a new icon for use in planner:

<img width="133" alt="Screen Shot 2021-07-08 at 9 27 49 AM" src="https://user-images.githubusercontent.com/1704236/124929912-dda88d00-dfce-11eb-8985-a4e9c817af6c.png">
